### PR TITLE
fix: Set default state of Obstacles and Hotspots toggles to disabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,9 @@
 - use github cli to interact with issues, pull requests (PR), branches, commits, etc. to keep the workflow smooth and fast
 - before starting development of specific issue, describe you plan in the issue as comment, so I can review it and give you feedback about the implementation plan
 - for each issue create new branch from main branch with the name of the issue, so it is clear what you are working on and once ready, create pull request
-- add comments to issue when you start working on it, so I know you are working on it, also add comments when you discovered something important what needs to be changed in the code because of issue, add to issue also description what you plan to do to implement the issue
+- add comments to issue when you start working on it, so I know you are working on it, add comments to issue when you discovered something important what needs to be changed in the code because of issue, add to issue also description what you plan to do to implement the issue with concept of changes
+- after you finish implementation and create pull request, make deep review of the pull request: analyze all changes, check if there are no duplicated codes, forgotten comments, performance improvements, maybe there are useless codes, which are not needed anymore and were done just for testing purpouses, etc.
+
 
 # Guide for Claude - Website development (Hugo CMS)
 

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -122,8 +122,8 @@ class MapScreenState extends State<MapScreen>
   final bool _showMetar = true; // METAR overlay always shown when data available
   bool _showHeliports = false; // Toggle for heliport display (default hidden)
   bool _showAirspaces = true; // Toggle for airspaces display
-  bool _showObstacles = true; // Toggle for obstacles display
-  bool _showHotspots = true; // Toggle for hotspots display
+  bool _showObstacles = false; // Toggle for obstacles display
+  bool _showHotspots = false; // Toggle for hotspots display
   bool _servicesInitialized = false;
   bool _isInitializing = false; // Guard against concurrent initialization
   bool _showFlightPlanning = false; // Toggle for integrated flight planning


### PR DESCRIPTION
## Summary
- Changed the initial state of Obstacles and Hotspots toggle buttons to be disabled by default when the application starts
- Modified `_showObstacles` and `_showHotspots` from `true` to `false` in `map_screen.dart`

## Changes
- Updated line 125: `bool _showObstacles = false;`  
- Updated line 126: `bool _showHotspots = false;`

## Test plan
- [x] Start the application
- [x] Verify that Obstacles toggle button is disabled (not blue) by default
- [x] Verify that Hotspots toggle button is disabled (not blue) by default
- [x] Verify that clicking the toggle buttons enables them and shows the respective data
- [x] Build passes without errors

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)