### PR TITLE
feat: Auto-rename waypoints when dropped on map markers

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1870,9 +1870,7 @@ class MapScreenState extends State<MapScreen>
           ? closestAirport.icaoCode! 
           : (closestAirport.iataCode ?? closestAirport.icao));
       // Update waypoint type to airport
-      final waypoint = _flightPlanService.currentFlightPlan!.waypoints[waypointIndex];
-      waypoint.type = WaypointType.airport;
-      _flightPlanService.notifyListeners();
+      _flightPlanService.updateWaypointType(waypointIndex, WaypointType.airport);
       return;
     } else if (airports.isEmpty) {
       debugPrint('No airports loaded in current view');
@@ -1908,9 +1906,7 @@ class MapScreenState extends State<MapScreen>
       _flightPlanService.updateWaypointName(waypointIndex, closestNavaid.name);
       _flightPlanService.updateWaypointNotes(waypointIndex, closestNavaid.ident);
       // Update waypoint type to navaid
-      final waypoint = _flightPlanService.currentFlightPlan!.waypoints[waypointIndex];
-      waypoint.type = WaypointType.navaid;
-      _flightPlanService.notifyListeners();
+      _flightPlanService.updateWaypointType(waypointIndex, WaypointType.navaid);
       return;
     }
     
@@ -1933,9 +1929,7 @@ class MapScreenState extends State<MapScreen>
         _flightPlanService.updateWaypointName(waypointIndex, closestPoint.displayName);
         _flightPlanService.updateWaypointNotes(waypointIndex, closestPoint.type ?? 'Reporting Point');
         // Update waypoint type to reporting point
-        final waypoint = _flightPlanService.currentFlightPlan!.waypoints[waypointIndex];
-        waypoint.type = WaypointType.reportingPoint;
-        _flightPlanService.notifyListeners();
+        _flightPlanService.updateWaypointType(waypointIndex, WaypointType.reportingPoint);
         return;
       }
     }

--- a/lib/services/flight_plan_service.dart
+++ b/lib/services/flight_plan_service.dart
@@ -364,6 +364,17 @@ class FlightPlanService extends ChangeNotifier {
       notifyListeners();
     }
   }
+  
+  // Update waypoint type
+  void updateWaypointType(int index, WaypointType type) {
+    if (_currentFlightPlan != null &&
+        index >= 0 &&
+        index < _currentFlightPlan!.waypoints.length) {
+      _currentFlightPlan!.waypoints[index].type = type;
+      _currentFlightPlan!.modifiedAt = DateTime.now();
+      notifyListeners();
+    }
+  }
 
   // Update waypoint position (for drag and drop on map)
   void updateWaypointPosition(int index, LatLng newPosition, {bool isDragging = false}) {

--- a/lib/services/flight_plan_service.dart
+++ b/lib/services/flight_plan_service.dart
@@ -365,7 +365,7 @@ class FlightPlanService extends ChangeNotifier {
     }
   }
   
-  // Update waypoint type
+  /// Update waypoint type (airport, navaid, user, etc.)
   void updateWaypointType(int index, WaypointType type) {
     if (_currentFlightPlan != null &&
         index >= 0 &&

--- a/lib/widgets/waypoint_table_widget.dart
+++ b/lib/widgets/waypoint_table_widget.dart
@@ -93,6 +93,12 @@ class _WaypointTableWidgetState extends State<WaypointTableWidget>
       _nameControllers[waypoint.id] = TextEditingController(
         text: waypoint.name ?? '',
       );
+    } else {
+      // Update controller text if waypoint name has changed
+      final controller = _nameControllers[waypoint.id]!;
+      if (controller.text != (waypoint.name ?? '')) {
+        controller.text = waypoint.name ?? '';
+      }
     }
     return _nameControllers[waypoint.id]!;
   }


### PR DESCRIPTION
## Summary
- ✅ Waypoints automatically rename when dropped on airports, navaids, or reporting points
- ✅ Smart detection within 50m radius of drop position
- ✅ Updates waypoint name, type, and notes appropriately
- ✅ Preserves exact drop position for precision

## Implementation Details

When a waypoint is dragged and dropped onto an existing marker on the map, it now automatically inherits that marker's information:

1. **Airport Drop**: Waypoint gets airport name, ICAO/IATA code in notes, and airport type
2. **Navaid Drop**: Waypoint gets navaid name, identifier in notes, and navaid type  
3. **Reporting Point Drop**: Waypoint gets reporting point name, type in notes, and reporting point type

### Technical Details
- Added `_checkAndUpdateWaypointForMarker()` method that runs after drop completes
- Searches markers within 50m radius to account for UI precision
- Priority order: airports → navaids → reporting points
- Updates waypoint properties while preserving exact drop position
- No snapping - maintains user's precise placement

## Test Plan
- [x] Build compiles without errors
- [ ] Drag waypoint and drop on airport - waypoint renamed
- [ ] Drag waypoint and drop on navaid - waypoint renamed
- [ ] Drag waypoint and drop on reporting point - waypoint renamed
- [ ] Drag waypoint to empty area - remains user waypoint
- [ ] Verify exact drop position is preserved (no snapping)

Resolves #17

🤖 Generated with [Claude Code](https://claude.ai/code)