### PR TITLE
feat: automatic map tile downloads for saved flight plans

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -564,6 +564,9 @@ class MapScreenState extends State<MapScreen>
     _locationRetryTimer?.cancel();
     _locationStreamSubscription?.cancel();
     
+    // Cancel any active tile downloads
+    _tileDownloadService?.cancelAllDownloads();
+    
     _flightService.removeListener(_onFlightPathUpdated);
     _flightPlanService.removeListener(_onFlightPlanUpdated);
     _cacheService.removeListener(_onCacheUpdated);
@@ -576,6 +579,7 @@ class MapScreenState extends State<MapScreen>
     _mapController.dispose();
     _flightService.dispose();
     _spatialAirspaceService?.dispose();
+    _offlineDataController?.dispose();
     super.dispose();
   }
 

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -36,6 +36,8 @@ import '../services/weather_service.dart';
 import '../services/offline_map_service.dart';
 import '../services/offline_tile_provider.dart';
 import '../services/flight_plan_service.dart';
+import '../services/flight_plan_tile_download_service.dart';
+import '../screens/offline_data/controllers/offline_data_state_controller.dart';
 import '../widgets/navaid_marker.dart';
 import '../widgets/optimized_marker_layer.dart';
 import '../widgets/airport_info_sheet.dart';
@@ -96,6 +98,8 @@ class MapScreenState extends State<MapScreen>
   OfflineMapService?
   _offlineMapService; // Make nullable to prevent LateInitializationError
   late final FlightPlanService _flightPlanService;
+  FlightPlanTileDownloadService? _tileDownloadService;
+  OfflineDataStateController? _offlineDataController;
   OpenAIPService? _openAIPService;
   SpatialAirspaceService? _spatialAirspaceService;
   late final MapController _mapController;
@@ -2716,6 +2720,19 @@ class MapScreenState extends State<MapScreen>
         try {
           _offlineMapService = OfflineMapService();
           await _offlineMapService!.initialize();
+          
+          // Initialize tile download service for flight plans
+          _offlineDataController = OfflineDataStateController();
+          _tileDownloadService = FlightPlanTileDownloadService(
+            offlineMapService: _offlineMapService!,
+            offlineDataController: _offlineDataController!,
+          );
+          
+          // Connect tile download service to flight plan service
+          _flightPlanService.setTileDownloadService(_tileDownloadService!);
+          if (mounted) {
+            _flightPlanService.setContext(context);
+          }
         } catch (e) {
           // Handle initialization errors gracefully
           _logger.w('Offline maps not available: ${e.toString().split('(')[0]}');

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -557,19 +557,15 @@ class MapScreenState extends State<MapScreen>
 
   /// Validate flight plan tiles on startup
   Future<void> _validateFlightPlanTiles() async {
-    debugPrint('MapScreen: Starting flight plan tile validation');
-    
     // Wait a bit to ensure UI is ready and flight plans are loaded
     await Future.delayed(const Duration(seconds: 2));
     
     if (!mounted || _tileDownloadService == null || _offlineDataController == null) {
-      debugPrint('MapScreen: Cannot validate - services not ready');
       return;
     }
     
     // Check if validation is enabled
     if (!_offlineDataController!.validateTilesOnStartup) {
-      debugPrint('MapScreen: Tile validation is disabled in settings');
       return;
     }
     
@@ -579,7 +575,6 @@ class MapScreenState extends State<MapScreen>
       
       // Get all saved flight plans
       final flightPlans = _flightPlanService.savedFlightPlans;
-      debugPrint('MapScreen: Found ${flightPlans.length} saved flight plans to validate');
       if (flightPlans.isEmpty) return;
       
       // Show progress indicator
@@ -600,9 +595,7 @@ class MapScreenState extends State<MapScreen>
       }
       
       // Validate all flight plans
-      debugPrint('MapScreen: Validating flight plans for missing tiles...');
       final validationResults = await _tileDownloadService!.validateAllFlightPlans(flightPlans);
-      debugPrint('MapScreen: Validation complete - ${validationResults.length} flight plans have missing tiles');
       
       // Close progress dialog
       if (mounted) {
@@ -611,13 +604,9 @@ class MapScreenState extends State<MapScreen>
       
       // If there are missing tiles, show dialog
       if (validationResults.isNotEmpty && mounted) {
-        debugPrint('MapScreen: Showing missing tiles dialog');
         await _showMissingTilesDialog(validationResults);
-      } else {
-        debugPrint('MapScreen: All flight plans have complete tile coverage');
       }
     } catch (e) {
-      debugPrint('Error validating flight plan tiles: $e');
       // Close progress dialog if still showing
       if (mounted && Navigator.canPop(context)) {
         Navigator.of(context).pop();

--- a/lib/screens/offline_data/controllers/offline_data_state_controller.dart
+++ b/lib/screens/offline_data/controllers/offline_data_state_controller.dart
@@ -1,7 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// State controller for offline data screen
 class OfflineDataStateController extends ChangeNotifier {
+  static const String _keyMinZoom = 'offline_min_zoom';
+  static const String _keyMaxZoom = 'offline_max_zoom';
+  static const String _keyDownloadMapTilesForFlightPlan = 'download_map_tiles_for_flight_plan';
+  
+  SharedPreferences? _prefs;
   bool _isLoading = true;
   bool _isRefreshing = false;
   bool _isDownloading = false;
@@ -12,6 +18,7 @@ class OfflineDataStateController extends ChangeNotifier {
   int _downloadedTiles = 0;
   int _minZoom = 8;
   int _maxZoom = 14;
+  bool _downloadMapTilesForFlightPlan = true;
 
   // Cache statistics
   Map<String, dynamic>? _mapCacheStats;
@@ -28,8 +35,27 @@ class OfflineDataStateController extends ChangeNotifier {
   int get downloadedTiles => _downloadedTiles;
   int get minZoom => _minZoom;
   int get maxZoom => _maxZoom;
+  bool get downloadMapTilesForFlightPlan => _downloadMapTilesForFlightPlan;
   Map<String, dynamic>? get mapCacheStats => _mapCacheStats;
   Map<String, dynamic> get cacheStats => _cacheStats;
+
+  OfflineDataStateController() {
+    _init();
+  }
+
+  Future<void> _init() async {
+    _prefs = await SharedPreferences.getInstance();
+    _loadSettings();
+  }
+
+  void _loadSettings() {
+    if (_prefs != null) {
+      _minZoom = _prefs!.getInt(_keyMinZoom) ?? 8;
+      _maxZoom = _prefs!.getInt(_keyMaxZoom) ?? 14;
+      _downloadMapTilesForFlightPlan = _prefs!.getBool(_keyDownloadMapTilesForFlightPlan) ?? true;
+      notifyListeners();
+    }
+  }
 
   // Setters
   void setLoading(bool value) {
@@ -75,6 +101,7 @@ class OfflineDataStateController extends ChangeNotifier {
     if (_minZoom > _maxZoom) {
       _maxZoom = _minZoom;
     }
+    _prefs?.setInt(_keyMinZoom, _minZoom);
     notifyListeners();
   }
 
@@ -83,9 +110,15 @@ class OfflineDataStateController extends ChangeNotifier {
     if (_maxZoom < _minZoom) {
       _minZoom = _maxZoom;
     }
+    _prefs?.setInt(_keyMaxZoom, _maxZoom);
     notifyListeners();
   }
 
+  void setDownloadMapTilesForFlightPlan(bool value) {
+    _downloadMapTilesForFlightPlan = value;
+    _prefs?.setBool(_keyDownloadMapTilesForFlightPlan, value);
+    notifyListeners();
+  }
 
   void setMapCacheStats(Map<String, dynamic>? stats) {
     _mapCacheStats = stats;

--- a/lib/screens/offline_data/controllers/offline_data_state_controller.dart
+++ b/lib/screens/offline_data/controllers/offline_data_state_controller.dart
@@ -6,6 +6,7 @@ class OfflineDataStateController extends ChangeNotifier {
   static const String _keyMinZoom = 'offline_min_zoom';
   static const String _keyMaxZoom = 'offline_max_zoom';
   static const String _keyDownloadMapTilesForFlightPlan = 'download_map_tiles_for_flight_plan';
+  static const String _keyValidateTilesOnStartup = 'validate_tiles_on_startup';
   
   SharedPreferences? _prefs;
   bool _isLoading = true;
@@ -19,6 +20,7 @@ class OfflineDataStateController extends ChangeNotifier {
   int _minZoom = 8;
   int _maxZoom = 14;
   bool _downloadMapTilesForFlightPlan = true;
+  bool _validateTilesOnStartup = true;
 
   // Cache statistics
   Map<String, dynamic>? _mapCacheStats;
@@ -36,6 +38,7 @@ class OfflineDataStateController extends ChangeNotifier {
   int get minZoom => _minZoom;
   int get maxZoom => _maxZoom;
   bool get downloadMapTilesForFlightPlan => _downloadMapTilesForFlightPlan;
+  bool get validateTilesOnStartup => _validateTilesOnStartup;
   Map<String, dynamic>? get mapCacheStats => _mapCacheStats;
   Map<String, dynamic> get cacheStats => _cacheStats;
 
@@ -53,6 +56,7 @@ class OfflineDataStateController extends ChangeNotifier {
       _minZoom = _prefs!.getInt(_keyMinZoom) ?? 8;
       _maxZoom = _prefs!.getInt(_keyMaxZoom) ?? 14;
       _downloadMapTilesForFlightPlan = _prefs!.getBool(_keyDownloadMapTilesForFlightPlan) ?? true;
+      _validateTilesOnStartup = _prefs!.getBool(_keyValidateTilesOnStartup) ?? true;
       notifyListeners();
     }
   }
@@ -117,6 +121,12 @@ class OfflineDataStateController extends ChangeNotifier {
   void setDownloadMapTilesForFlightPlan(bool value) {
     _downloadMapTilesForFlightPlan = value;
     _prefs?.setBool(_keyDownloadMapTilesForFlightPlan, value);
+    notifyListeners();
+  }
+  
+  void setValidateTilesOnStartup(bool value) {
+    _validateTilesOnStartup = value;
+    _prefs?.setBool(_keyValidateTilesOnStartup, value);
     notifyListeners();
   }
 

--- a/lib/screens/offline_data/sections/download_map_tiles_section.dart
+++ b/lib/screens/offline_data/sections/download_map_tiles_section.dart
@@ -26,6 +26,25 @@ class DownloadMapTilesSection extends StatelessWidget {
           style: TextStyle(color: AppColors.secondaryTextColor),
         ),
         const SizedBox(height: 16),
+        CheckboxListTile(
+          title: const Text(
+            'Flight plan - download map tiles',
+            style: TextStyle(color: AppColors.primaryTextColor),
+          ),
+          subtitle: const Text(
+            'Automatically download map tiles along saved flight plans',
+            style: TextStyle(color: AppColors.secondaryTextColor, fontSize: 12),
+          ),
+          value: controller.downloadMapTilesForFlightPlan,
+          onChanged: (value) {
+            if (value != null) {
+              controller.setDownloadMapTilesForFlightPlan(value);
+            }
+          },
+          activeColor: AppColors.primaryAccent,
+          contentPadding: EdgeInsets.zero,
+        ),
+        const SizedBox(height: 16),
         Row(
           children: [
             Expanded(

--- a/lib/screens/offline_data/sections/download_map_tiles_section.dart
+++ b/lib/screens/offline_data/sections/download_map_tiles_section.dart
@@ -44,6 +44,25 @@ class DownloadMapTilesSection extends StatelessWidget {
           activeColor: AppColors.primaryAccent,
           contentPadding: EdgeInsets.zero,
         ),
+        const SizedBox(height: 8),
+        CheckboxListTile(
+          title: const Text(
+            'Validate tiles on startup',
+            style: TextStyle(color: AppColors.primaryTextColor),
+          ),
+          subtitle: const Text(
+            'Check for missing flight plan tiles when app starts',
+            style: TextStyle(color: AppColors.secondaryTextColor, fontSize: 12),
+          ),
+          value: controller.validateTilesOnStartup,
+          onChanged: (value) {
+            if (value != null) {
+              controller.setValidateTilesOnStartup(value);
+            }
+          },
+          activeColor: AppColors.primaryAccent,
+          contentPadding: EdgeInsets.zero,
+        ),
         const SizedBox(height: 16),
         Row(
           children: [

--- a/lib/screens/offline_data_screen.dart
+++ b/lib/screens/offline_data_screen.dart
@@ -20,10 +20,12 @@ import 'offline_data/helpers/cache_statistics_helper.dart';
 /// Screen for managing all offline data and caches
 class OfflineDataScreen extends StatefulWidget {
   final LatLngBounds? currentMapBounds;
+  final OfflineDataStateController? stateController;
   
   const OfflineDataScreen({
     super.key,
     this.currentMapBounds,
+    this.stateController,
   });
 
   @override
@@ -39,18 +41,22 @@ class _OfflineDataScreenState extends State<OfflineDataScreen> {
   final TiledDataLoader _tiledDataLoader = TiledDataLoader();
   
   final ScrollController _scrollController = ScrollController();
-  final OfflineDataStateController _stateController = OfflineDataStateController();
+  late final OfflineDataStateController _stateController;
 
   @override
   void initState() {
     super.initState();
+    _stateController = widget.stateController ?? OfflineDataStateController();
     _loadAllCacheStats();
   }
 
   @override
   void dispose() {
     _scrollController.dispose();
-    _stateController.dispose();
+    // Only dispose if we created the controller
+    if (widget.stateController == null) {
+      _stateController.dispose();
+    }
     super.dispose();
   }
 

--- a/lib/services/flight_plan_service.dart
+++ b/lib/services/flight_plan_service.dart
@@ -78,10 +78,16 @@ class FlightPlanService extends ChangeNotifier {
       
       // Trigger automatic tile download if service is available
       if (_tileDownloadService != null && _context != null && _currentFlightPlan!.waypoints.isNotEmpty) {
+        debugPrint('FlightPlanService: Triggering tile download for ${_currentFlightPlan!.name}');
         _tileDownloadService!.downloadTilesForFlightPlan(
           flightPlan: _currentFlightPlan!,
           context: _context!,
         );
+      } else {
+        debugPrint('FlightPlanService: Cannot trigger tile download - '
+            'tileDownloadService: ${_tileDownloadService != null}, '
+            'context: ${_context != null}, '
+            'waypoints: ${_currentFlightPlan?.waypoints.length ?? 0}');
       }
     } catch (e) {
       // debugPrint('Error saving flight plan: $e');

--- a/lib/services/flight_plan_service.dart
+++ b/lib/services/flight_plan_service.dart
@@ -78,16 +78,10 @@ class FlightPlanService extends ChangeNotifier {
       
       // Trigger automatic tile download if service is available
       if (_tileDownloadService != null && _context != null && _currentFlightPlan!.waypoints.isNotEmpty) {
-        debugPrint('FlightPlanService: Triggering tile download for ${_currentFlightPlan!.name}');
         _tileDownloadService!.downloadTilesForFlightPlan(
           flightPlan: _currentFlightPlan!,
           context: _context!,
         );
-      } else {
-        debugPrint('FlightPlanService: Cannot trigger tile download - '
-            'tileDownloadService: ${_tileDownloadService != null}, '
-            'context: ${_context != null}, '
-            'waypoints: ${_currentFlightPlan?.waypoints.length ?? 0}');
       }
     } catch (e) {
       // debugPrint('Error saving flight plan: $e');

--- a/lib/services/flight_plan_tile_download_service.dart
+++ b/lib/services/flight_plan_tile_download_service.dart
@@ -1,0 +1,196 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:flutter_map/flutter_map.dart';
+import '../models/flight_plan.dart';
+import 'offline_map_service.dart';
+import '../screens/offline_data/controllers/offline_data_state_controller.dart';
+
+/// Service for downloading map tiles along flight plan routes
+class FlightPlanTileDownloadService {
+  final OfflineMapService _offlineMapService;
+  final OfflineDataStateController _offlineDataController;
+  
+  FlightPlanTileDownloadService({
+    required OfflineMapService offlineMapService,
+    required OfflineDataStateController offlineDataController,
+  })  : _offlineMapService = offlineMapService,
+        _offlineDataController = offlineDataController;
+
+  /// Download tiles for a flight plan route with a buffer
+  Future<void> downloadTilesForFlightPlan({
+    required FlightPlan flightPlan,
+    required BuildContext context,
+    double bufferKm = 10.0, // 10km buffer around route
+  }) async {
+    // Check if the feature is enabled
+    if (!_offlineDataController.downloadMapTilesForFlightPlan) {
+      return;
+    }
+
+    // Check if we have waypoints
+    if (flightPlan.waypoints.isEmpty) {
+      return;
+    }
+
+    // Calculate bounds for the entire route with buffer
+    final bounds = _calculateRouteBufferBounds(flightPlan.waypoints, bufferKm);
+    
+    // Show notification that download is starting
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Row(
+            children: [
+              SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                ),
+              ),
+              SizedBox(width: 16),
+              Expanded(
+                child: Text('Downloading map tiles for flight plan...'),
+              ),
+            ],
+          ),
+          duration: Duration(seconds: 5),
+          backgroundColor: Colors.blue,
+        ),
+      );
+    }
+
+    // Start background download
+    _downloadInBackground(
+      bounds: bounds,
+      minZoom: _offlineDataController.minZoom,
+      maxZoom: _offlineDataController.maxZoom,
+    );
+  }
+
+  /// Calculate bounds that include all waypoints with a buffer
+  LatLngBounds _calculateRouteBufferBounds(List<Waypoint> waypoints, double bufferKm) {
+    if (waypoints.isEmpty) {
+      throw ArgumentError('Waypoints list cannot be empty');
+    }
+
+    // Find initial bounds
+    double minLat = waypoints.first.latitude;
+    double maxLat = waypoints.first.latitude;
+    double minLng = waypoints.first.longitude;
+    double maxLng = waypoints.first.longitude;
+
+    for (final waypoint in waypoints) {
+      minLat = min(minLat, waypoint.latitude);
+      maxLat = max(maxLat, waypoint.latitude);
+      minLng = min(minLng, waypoint.longitude);
+      maxLng = max(maxLng, waypoint.longitude);
+    }
+
+    // Add buffer in kilometers
+    // Approximate conversion: 1 degree latitude = 111 km
+    // 1 degree longitude varies by latitude
+    final latBuffer = bufferKm / 111.0;
+    
+    // Calculate longitude buffer based on average latitude
+    final avgLat = (minLat + maxLat) / 2;
+    final lngBuffer = bufferKm / (111.0 * cos(avgLat * pi / 180));
+
+    // Apply buffer
+    minLat -= latBuffer;
+    maxLat += latBuffer;
+    minLng -= lngBuffer;
+    maxLng += lngBuffer;
+
+    // Ensure bounds are within valid ranges
+    minLat = max(minLat, -90.0);
+    maxLat = min(maxLat, 90.0);
+    minLng = max(minLng, -180.0);
+    maxLng = min(maxLng, 180.0);
+
+    return LatLngBounds(
+      LatLng(minLat, minLng),
+      LatLng(maxLat, maxLng),
+    );
+  }
+
+  /// Download tiles in background without blocking UI
+  Future<void> _downloadInBackground({
+    required LatLngBounds bounds,
+    required int minZoom,
+    required int maxZoom,
+  }) async {
+    try {
+      // Initialize offline map service if needed
+      await _offlineMapService.initialize();
+
+      // Start download without progress callback to avoid UI updates
+      await _offlineMapService.downloadAreaTiles(
+        bounds: bounds,
+        minZoom: minZoom,
+        maxZoom: maxZoom,
+      );
+    } catch (e) {
+      // Silently handle errors in background download
+      debugPrint('Error downloading flight plan tiles: $e');
+    }
+  }
+
+  /// Calculate estimated number of tiles for a flight plan
+  int estimateTilesForFlightPlan(FlightPlan flightPlan, double bufferKm) {
+    if (flightPlan.waypoints.isEmpty) {
+      return 0;
+    }
+
+    final bounds = _calculateRouteBufferBounds(flightPlan.waypoints, bufferKm);
+    int totalTiles = 0;
+
+    for (int z = _offlineDataController.minZoom; z <= _offlineDataController.maxZoom; z++) {
+      final tileBounds = _getTileBounds(bounds, z);
+      final tilesX = tileBounds.maxX - tileBounds.minX + 1;
+      final tilesY = tileBounds.maxY - tileBounds.minY + 1;
+      totalTiles += tilesX * tilesY;
+    }
+
+    return totalTiles;
+  }
+
+  /// Get tile bounds for a geographic area at a specific zoom level
+  _TileBounds _getTileBounds(LatLngBounds bounds, int zoom) {
+    final minTile = _latLngToTile(bounds.southWest, zoom);
+    final maxTile = _latLngToTile(bounds.northEast, zoom);
+    
+    return _TileBounds(
+      minX: minTile.x.floor(),
+      minY: maxTile.y.floor(),
+      maxX: maxTile.x.floor(),
+      maxY: minTile.y.floor(),
+    );
+  }
+
+  /// Convert lat/lng to tile coordinates
+  Point<double> _latLngToTile(LatLng latLng, int zoom) {
+    final n = pow(2, zoom);
+    final x = ((latLng.longitude + 180) / 360) * n;
+    final latRad = latLng.latitude * pi / 180;
+    final y = (1 - (log(tan(latRad) + (1 / cos(latRad))) / pi)) / 2 * n;
+    return Point(x, y);
+  }
+}
+
+/// Helper class for tile bounds
+class _TileBounds {
+  final int minX;
+  final int minY;
+  final int maxX;
+  final int maxY;
+
+  _TileBounds({
+    required this.minX,
+    required this.minY,
+    required this.maxX,
+    required this.maxY,
+  });
+}

--- a/lib/services/flight_plan_tile_download_service.dart
+++ b/lib/services/flight_plan_tile_download_service.dart
@@ -38,13 +38,17 @@ class FlightPlanTileDownloadService {
     required BuildContext context,
     double bufferKm = 10.0, // 10km buffer around route
   }) async {
+    debugPrint('FlightPlanTileDownloadService: downloadTilesForFlightPlan called for ${flightPlan.name}');
+    
     // Check if the feature is enabled
     if (!_offlineDataController.downloadMapTilesForFlightPlan) {
+      debugPrint('FlightPlanTileDownloadService: Feature is disabled in settings');
       return;
     }
 
     // Check if we have waypoints
     if (flightPlan.waypoints.isEmpty) {
+      debugPrint('FlightPlanTileDownloadService: No waypoints in flight plan');
       return;
     }
 
@@ -87,6 +91,7 @@ class FlightPlanTileDownloadService {
     final bounds = _calculateRouteBufferBounds(flightPlan.waypoints, bufferKm);
     
     // Show notification that download is starting
+    debugPrint('FlightPlanTileDownloadService: Showing download notification for $estimatedTiles tiles');
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -110,6 +115,8 @@ class FlightPlanTileDownloadService {
           backgroundColor: Colors.blue,
         ),
       );
+    } else {
+      debugPrint('FlightPlanTileDownloadService: Context not mounted, cannot show notification');
     }
 
     // Add to download queue
@@ -317,6 +324,8 @@ class FlightPlanTileDownloadService {
   
   /// Add download request to queue and process it
   void _addToQueue(_DownloadRequest request) {
+    debugPrint('FlightPlanTileDownloadService: Adding download request to queue');
+    
     // Check if this flight plan is already in queue
     final existingIndex = _downloadQueue.indexWhere((r) => r.flightPlanId == request.flightPlanId);
     if (existingIndex != -1) {
@@ -325,6 +334,8 @@ class FlightPlanTileDownloadService {
     } else {
       _downloadQueue.add(request);
     }
+    
+    debugPrint('FlightPlanTileDownloadService: Queue size: ${_downloadQueue.length}, Processing: $_isProcessingQueue');
     
     // Start processing queue if not already running
     if (!_isProcessingQueue) {
@@ -338,14 +349,17 @@ class FlightPlanTileDownloadService {
       return;
     }
     
+    debugPrint('FlightPlanTileDownloadService: Starting queue processing');
     _isProcessingQueue = true;
     
     try {
       while (_downloadQueue.isNotEmpty) {
         final request = _downloadQueue.removeAt(0);
+        debugPrint('FlightPlanTileDownloadService: Processing download for flight plan ${request.flightPlanId}');
         
         // Skip if already downloading
         if (_activeDownloads.containsKey(request.flightPlanId)) {
+          debugPrint('FlightPlanTileDownloadService: Skipping - already downloading');
           continue;
         }
         
@@ -358,6 +372,7 @@ class FlightPlanTileDownloadService {
       }
     } finally {
       _isProcessingQueue = false;
+      debugPrint('FlightPlanTileDownloadService: Queue processing complete');
     }
   }
 

--- a/lib/services/flight_plan_tile_download_service.dart
+++ b/lib/services/flight_plan_tile_download_service.dart
@@ -38,17 +38,13 @@ class FlightPlanTileDownloadService {
     required BuildContext context,
     double bufferKm = 10.0, // 10km buffer around route
   }) async {
-    debugPrint('FlightPlanTileDownloadService: downloadTilesForFlightPlan called for ${flightPlan.name}');
-    
     // Check if the feature is enabled
     if (!_offlineDataController.downloadMapTilesForFlightPlan) {
-      debugPrint('FlightPlanTileDownloadService: Feature is disabled in settings');
       return;
     }
 
     // Check if we have waypoints
     if (flightPlan.waypoints.isEmpty) {
-      debugPrint('FlightPlanTileDownloadService: No waypoints in flight plan');
       return;
     }
 
@@ -91,7 +87,6 @@ class FlightPlanTileDownloadService {
     final bounds = _calculateRouteBufferBounds(flightPlan.waypoints, bufferKm);
     
     // Show notification that download is starting
-    debugPrint('FlightPlanTileDownloadService: Showing download notification for $estimatedTiles tiles');
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -115,8 +110,6 @@ class FlightPlanTileDownloadService {
           backgroundColor: Colors.blue,
         ),
       );
-    } else {
-      debugPrint('FlightPlanTileDownloadService: Context not mounted, cannot show notification');
     }
 
     // Add to download queue
@@ -203,12 +196,11 @@ class FlightPlanTileDownloadService {
       
     } catch (e) {
       final errorMessage = 'Error downloading tiles for flight plan $flightPlanId: $e';
-      debugPrint(errorMessage);
       _addError(errorMessage);
       
       // Check if it was cancelled
       if (completer.isCanceled) {
-        debugPrint('Download cancelled for flight plan $flightPlanId');
+        // Download was cancelled
       }
     } finally {
       _activeDownloads.remove(flightPlanId);
@@ -255,12 +247,10 @@ class FlightPlanTileDownloadService {
   
   /// Validate that all tiles are downloaded for saved flight plans
   Future<List<FlightPlanValidationResult>> validateAllFlightPlans(List<FlightPlan> flightPlans) async {
-    debugPrint('FlightPlanTileDownloadService: Validating ${flightPlans.length} flight plans');
     final results = <FlightPlanValidationResult>[];
     
     // Only validate if the feature is enabled
     if (!_offlineDataController.downloadMapTilesForFlightPlan) {
-      debugPrint('FlightPlanTileDownloadService: Validation skipped - download feature is disabled');
       return results;
     }
     
@@ -285,7 +275,7 @@ class FlightPlanTileDownloadService {
           ));
         }
       } catch (e) {
-        debugPrint('Error validating flight plan ${flightPlan.name}: $e');
+        // Error validating flight plan
       }
     }
     
@@ -318,7 +308,7 @@ class FlightPlanTileDownloadService {
         }
       }
     } catch (e) {
-      debugPrint('Error checking missing tiles: $e');
+      // Error checking missing tiles
     }
     
     return missingCount;
@@ -326,8 +316,6 @@ class FlightPlanTileDownloadService {
   
   /// Add download request to queue and process it
   void _addToQueue(_DownloadRequest request) {
-    debugPrint('FlightPlanTileDownloadService: Adding download request to queue');
-    
     // Check if this flight plan is already in queue
     final existingIndex = _downloadQueue.indexWhere((r) => r.flightPlanId == request.flightPlanId);
     if (existingIndex != -1) {
@@ -336,8 +324,6 @@ class FlightPlanTileDownloadService {
     } else {
       _downloadQueue.add(request);
     }
-    
-    debugPrint('FlightPlanTileDownloadService: Queue size: ${_downloadQueue.length}, Processing: $_isProcessingQueue');
     
     // Start processing queue if not already running
     if (!_isProcessingQueue) {

--- a/lib/services/flight_plan_tile_download_service.dart
+++ b/lib/services/flight_plan_tile_download_service.dart
@@ -351,17 +351,14 @@ class FlightPlanTileDownloadService {
       return;
     }
     
-    debugPrint('FlightPlanTileDownloadService: Starting queue processing');
     _isProcessingQueue = true;
     
     try {
       while (_downloadQueue.isNotEmpty) {
         final request = _downloadQueue.removeAt(0);
-        debugPrint('FlightPlanTileDownloadService: Processing download for flight plan ${request.flightPlanId}');
         
         // Skip if already downloading
         if (_activeDownloads.containsKey(request.flightPlanId)) {
-          debugPrint('FlightPlanTileDownloadService: Skipping - already downloading');
           continue;
         }
         
@@ -374,7 +371,6 @@ class FlightPlanTileDownloadService {
       }
     } finally {
       _isProcessingQueue = false;
-      debugPrint('FlightPlanTileDownloadService: Queue processing complete');
     }
   }
 

--- a/lib/services/flight_plan_tile_download_service.dart
+++ b/lib/services/flight_plan_tile_download_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:latlong2/latlong.dart';
@@ -8,8 +9,22 @@ import '../screens/offline_data/controllers/offline_data_state_controller.dart';
 
 /// Service for downloading map tiles along flight plan routes
 class FlightPlanTileDownloadService {
+  static const int maxTilesPerDownload = 5000; // Maximum tiles to download at once
+  static const double kmPerLatDegree = 111.0; // Approximate km per degree latitude
+  
   final OfflineMapService _offlineMapService;
   final OfflineDataStateController _offlineDataController;
+  
+  // Track active downloads for cancellation
+  final Map<String, CancelableOperation<dynamic>> _activeDownloads = {};
+  
+  // Download queue to manage multiple requests
+  final List<_DownloadRequest> _downloadQueue = [];
+  bool _isProcessingQueue = false;
+  
+  // Error log for user visibility
+  final List<String> _errorLog = [];
+  List<String> get errorLog => List.unmodifiable(_errorLog);
   
   FlightPlanTileDownloadService({
     required OfflineMapService offlineMapService,
@@ -33,16 +48,51 @@ class FlightPlanTileDownloadService {
       return;
     }
 
+    // Estimate tile count first
+    final estimatedTiles = estimateTilesForFlightPlan(flightPlan, bufferKm);
+    
+    // Check if tile count exceeds limit
+    if (estimatedTiles > maxTilesPerDownload) {
+      if (context.mounted) {
+        final result = await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('Large Download Warning'),
+            content: Text(
+              'This flight plan requires downloading approximately $estimatedTiles map tiles, '
+              'which exceeds the recommended limit of $maxTilesPerDownload tiles. '
+              'This may take a long time and use significant storage space.\n\n'
+              'Do you want to continue?',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('Cancel'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('Continue'),
+              ),
+            ],
+          ),
+        );
+        
+        if (result != true) {
+          return;
+        }
+      }
+    }
+
     // Calculate bounds for the entire route with buffer
     final bounds = _calculateRouteBufferBounds(flightPlan.waypoints, bufferKm);
     
     // Show notification that download is starting
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
+        SnackBar(
           content: Row(
             children: [
-              SizedBox(
+              const SizedBox(
                 width: 20,
                 height: 20,
                 child: CircularProgressIndicator(
@@ -50,24 +100,25 @@ class FlightPlanTileDownloadService {
                   valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
                 ),
               ),
-              SizedBox(width: 16),
+              const SizedBox(width: 16),
               Expanded(
-                child: Text('Downloading map tiles for flight plan...'),
+                child: Text('Downloading $estimatedTiles map tiles for flight plan...'),
               ),
             ],
           ),
-          duration: Duration(seconds: 5),
+          duration: const Duration(seconds: 5),
           backgroundColor: Colors.blue,
         ),
       );
     }
 
-    // Start background download
-    _downloadInBackground(
+    // Add to download queue
+    _addToQueue(_DownloadRequest(
+      flightPlanId: flightPlan.id,
       bounds: bounds,
       minZoom: _offlineDataController.minZoom,
       maxZoom: _offlineDataController.maxZoom,
-    );
+    ));
   }
 
   /// Calculate bounds that include all waypoints with a buffer
@@ -90,13 +141,11 @@ class FlightPlanTileDownloadService {
     }
 
     // Add buffer in kilometers
-    // Approximate conversion: 1 degree latitude = 111 km
-    // 1 degree longitude varies by latitude
-    final latBuffer = bufferKm / 111.0;
+    final latBuffer = bufferKm / kmPerLatDegree;
     
     // Calculate longitude buffer based on average latitude
     final avgLat = (minLat + maxLat) / 2;
-    final lngBuffer = bufferKm / (111.0 * cos(avgLat * pi / 180));
+    final lngBuffer = bufferKm / (kmPerLatDegree * cos(avgLat * pi / 180));
 
     // Apply buffer
     minLat -= latBuffer;
@@ -118,23 +167,128 @@ class FlightPlanTileDownloadService {
 
   /// Download tiles in background without blocking UI
   Future<void> _downloadInBackground({
+    required String flightPlanId,
     required LatLngBounds bounds,
     required int minZoom,
     required int maxZoom,
   }) async {
+    // Cancel any existing download for this flight plan
+    await cancelDownload(flightPlanId);
+    
+    // Create cancelable operation
+    final completer = CancelableCompleter<Map<String, int>>();
+    _activeDownloads[flightPlanId] = completer.operation;
+    
     try {
       // Initialize offline map service if needed
       await _offlineMapService.initialize();
 
       // Start download without progress callback to avoid UI updates
-      await _offlineMapService.downloadAreaTiles(
+      final downloadFuture = _offlineMapService.downloadAreaTiles(
         bounds: bounds,
         minZoom: minZoom,
         maxZoom: maxZoom,
       );
+      
+      // Make the download cancelable
+      completer.complete(downloadFuture);
+      await completer.operation.value;
+      
     } catch (e) {
-      // Silently handle errors in background download
-      debugPrint('Error downloading flight plan tiles: $e');
+      final errorMessage = 'Error downloading tiles for flight plan $flightPlanId: $e';
+      debugPrint(errorMessage);
+      _addError(errorMessage);
+      
+      // Check if it was cancelled
+      if (completer.isCanceled) {
+        debugPrint('Download cancelled for flight plan $flightPlanId');
+      }
+    } finally {
+      _activeDownloads.remove(flightPlanId);
+    }
+  }
+  
+  /// Cancel a download for a specific flight plan
+  Future<void> cancelDownload(String flightPlanId) async {
+    final operation = _activeDownloads[flightPlanId];
+    if (operation != null) {
+      operation.cancel();
+      _activeDownloads.remove(flightPlanId);
+    }
+  }
+  
+  /// Cancel all active downloads
+  Future<void> cancelAllDownloads() async {
+    // Cancel active downloads
+    for (final operation in _activeDownloads.values) {
+      operation.cancel();
+    }
+    _activeDownloads.clear();
+    
+    // Clear the download queue
+    _downloadQueue.clear();
+    _isProcessingQueue = false;
+  }
+  
+  /// Add error to log with timestamp
+  void _addError(String error) {
+    final timestamp = DateTime.now().toIso8601String();
+    _errorLog.add('$timestamp: $error');
+    
+    // Keep only last 50 errors
+    if (_errorLog.length > 50) {
+      _errorLog.removeAt(0);
+    }
+  }
+  
+  /// Clear error log
+  void clearErrorLog() {
+    _errorLog.clear();
+  }
+  
+  /// Add download request to queue and process it
+  void _addToQueue(_DownloadRequest request) {
+    // Check if this flight plan is already in queue
+    final existingIndex = _downloadQueue.indexWhere((r) => r.flightPlanId == request.flightPlanId);
+    if (existingIndex != -1) {
+      // Replace existing request with new one
+      _downloadQueue[existingIndex] = request;
+    } else {
+      _downloadQueue.add(request);
+    }
+    
+    // Start processing queue if not already running
+    if (!_isProcessingQueue) {
+      _processQueue();
+    }
+  }
+  
+  /// Process download queue sequentially
+  Future<void> _processQueue() async {
+    if (_isProcessingQueue || _downloadQueue.isEmpty) {
+      return;
+    }
+    
+    _isProcessingQueue = true;
+    
+    try {
+      while (_downloadQueue.isNotEmpty) {
+        final request = _downloadQueue.removeAt(0);
+        
+        // Skip if already downloading
+        if (_activeDownloads.containsKey(request.flightPlanId)) {
+          continue;
+        }
+        
+        await _downloadInBackground(
+          flightPlanId: request.flightPlanId,
+          bounds: request.bounds,
+          minZoom: request.minZoom,
+          maxZoom: request.maxZoom,
+        );
+      }
+    } finally {
+      _isProcessingQueue = false;
     }
   }
 
@@ -192,5 +346,59 @@ class _TileBounds {
     required this.minY,
     required this.maxX,
     required this.maxY,
+  });
+}
+
+/// Completer that can be cancelled
+class CancelableCompleter<T> {
+  final _completer = Completer<T>();
+  bool _isCanceled = false;
+  
+  bool get isCanceled => _isCanceled;
+  CancelableOperation<T> get operation => CancelableOperation._(_completer.future, this);
+  
+  void complete([FutureOr<T>? value]) {
+    if (!_isCanceled && !_completer.isCompleted) {
+      _completer.complete(value);
+    }
+  }
+  
+  void completeError(Object error, [StackTrace? stackTrace]) {
+    if (!_isCanceled && !_completer.isCompleted) {
+      _completer.completeError(error, stackTrace);
+    }
+  }
+  
+  void cancel() {
+    _isCanceled = true;
+  }
+}
+
+/// Operation that can be cancelled
+class CancelableOperation<T> {
+  final Future<T> _future;
+  final CancelableCompleter<T> _completer;
+  
+  CancelableOperation._(this._future, this._completer);
+  
+  Future<T> get value => _future;
+  
+  void cancel() {
+    _completer.cancel();
+  }
+}
+
+/// Download request for queue management
+class _DownloadRequest {
+  final String flightPlanId;
+  final LatLngBounds bounds;
+  final int minZoom;
+  final int maxZoom;
+  
+  _DownloadRequest({
+    required this.flightPlanId,
+    required this.bounds,
+    required this.minZoom,
+    required this.maxZoom,
   });
 }

--- a/lib/services/flight_plan_tile_download_service.dart
+++ b/lib/services/flight_plan_tile_download_service.dart
@@ -255,10 +255,12 @@ class FlightPlanTileDownloadService {
   
   /// Validate that all tiles are downloaded for saved flight plans
   Future<List<FlightPlanValidationResult>> validateAllFlightPlans(List<FlightPlan> flightPlans) async {
+    debugPrint('FlightPlanTileDownloadService: Validating ${flightPlans.length} flight plans');
     final results = <FlightPlanValidationResult>[];
     
     // Only validate if the feature is enabled
     if (!_offlineDataController.downloadMapTilesForFlightPlan) {
+      debugPrint('FlightPlanTileDownloadService: Validation skipped - download feature is disabled');
       return results;
     }
     

--- a/lib/services/spatial_airspace_service.dart
+++ b/lib/services/spatial_airspace_service.dart
@@ -44,13 +44,9 @@ class SpatialAirspaceService extends ChangeNotifier {
     final airspaces = await _openAIPService.getCachedAirspaces();
     if (airspaces.isNotEmpty) {
       _allAirspaces = airspaces;
-      developer.log('🚀 Spatial index will be built dynamically as tiles are loaded');
-      developer.log('📊 Managing ${airspaces.length} airspaces');
       _isIndexBuilt = true;
       notifyListeners();
     } else {
-      developer.log('⚠️ No cached airspaces available, initializing with empty index');
-      developer.log('📡 Airspaces will be loaded on-demand from tiled data');
       _allAirspaces = [];
       _isIndexBuilt = true; // Allow queries even with empty initial data
       notifyListeners();
@@ -95,8 +91,7 @@ class SpatialAirspaceService extends ChangeNotifier {
     
     // Query the spatial index
     var candidates = spatialIndex.search(bounds).whereType<Airspace>().toList();
-    developer.log('🔨 Using dynamic spatial index: found ${candidates.length} airspaces');
-    
+
     // Apply additional filters
     if (currentAltitude != null || typeFilter != null || icaoClassFilter != null) {
       candidates = candidates.where((airspace) {
@@ -120,8 +115,7 @@ class SpatialAirspaceService extends ChangeNotifier {
     }
 
     final queryTime = DateTime.now().difference(startTime).inMicroseconds;
-    developer.log('🚀 Spatial query completed in $queryTimeμs, found ${candidates.length} airspaces');
-    
+
     return candidates;
   }
 
@@ -134,7 +128,6 @@ class SpatialAirspaceService extends ChangeNotifier {
     await _ensureIndexBuilt();
     
     if (!_isIndexBuilt) {
-      developer.log('⚠️ Spatial index not ready, skipping query');
       return [];
     }
 
@@ -158,8 +151,7 @@ class SpatialAirspaceService extends ChangeNotifier {
     
     // Query the spatial index
     var candidates = spatialIndex.searchPoint(point).whereType<Airspace>().toList();
-    developer.log('🔨 Using dynamic spatial index for point: found ${candidates.length} airspaces');
-    
+
     // Apply additional filters
     if (currentAltitude != null || typeFilter != null || icaoClassFilter != null) {
       candidates = candidates.where((airspace) {

--- a/lib/services/spatial_airspace_service.dart
+++ b/lib/services/spatial_airspace_service.dart
@@ -71,8 +71,6 @@ class SpatialAirspaceService extends ChangeNotifier {
       developer.log('⚠️ Spatial index not ready, skipping query');
       return [];
     }
-
-    final startTime = DateTime.now();
     
     // First, ensure the tiles for this area are loaded
     await _tiledDataLoader.loadAirspacesForArea(
@@ -114,8 +112,6 @@ class SpatialAirspaceService extends ChangeNotifier {
       }).toList();
     }
 
-    final queryTime = DateTime.now().difference(startTime).inMicroseconds;
-
     return candidates;
   }
 
@@ -130,8 +126,6 @@ class SpatialAirspaceService extends ChangeNotifier {
     if (!_isIndexBuilt) {
       return [];
     }
-
-    final startTime = DateTime.now();
     
     // First, ensure the tiles for this area are loaded (small area around the point)
     const buffer = 0.1; // degrees
@@ -174,9 +168,6 @@ class SpatialAirspaceService extends ChangeNotifier {
       }).toList();
     }
 
-    final queryTime = DateTime.now().difference(startTime).inMicroseconds;
-    developer.log('⚡ Point query completed in $queryTimeμs, found ${candidates.length} airspaces');
-    
     return candidates;
   }
 


### PR DESCRIPTION
## Summary
Implements automatic background downloading of map tiles along flight plan routes to ensure offline availability.

## Implementation Details
- Added checkbox setting "Flight plan - download map tiles" in offline data form (enabled by default)
- Created `FlightPlanTileDownloadService` to handle automatic tile downloads
- Integrated with `FlightPlanService` to trigger downloads when flight plans are saved
- Downloads tiles with 10km buffer around flight route
- Uses configured min/max zoom levels from offline data settings
- Skips already cached tiles to avoid redundant downloads
- Downloads run in background without blocking UI
- Shows 5-second notification when download starts

## Test Plan
1. Enable "Flight plan - download map tiles" setting in Settings > Offline Data (should be enabled by default)
2. Create a new flight plan with multiple waypoints
3. Save the flight plan
4. Verify notification appears showing "Downloading map tiles for flight plan..."
5. Check offline data statistics to see increased tile count
6. Disable the setting and save another flight plan
7. Verify no download notification appears
8. Go offline and verify downloaded tiles are available along the flight route

Closes #69

🤖 Generated with Claude Code