### PR TITLE
Fix aircraft marker rotation behavior

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -3460,10 +3460,8 @@ class MapScreenState extends State<MapScreen>
               if (_currentPosition != null)
                 Consumer<SettingsService>(
                   builder: (context, settings, child) {
-                    // When rotateMapWithHeading is ON: map rotates, so aircraft marker stays pointing north (no rotation)
-                    // When rotateMapWithHeading is OFF: map stays north, so aircraft marker rotates to show heading
-                    final shouldRotateMarker = !settings.rotateMapWithHeading;
-                    final markerRotation = shouldRotateMarker ? (_currentPosition?.heading ?? 0) * math.pi / 180 : 0.0;
+                    // Aircraft marker should always rotate by heading angle
+                    final markerRotation = (_currentPosition?.heading ?? 0) * math.pi / 180;
                     
                     return MarkerLayer(
                       markers: [


### PR DESCRIPTION
## Summary
- Simplify aircraft marker rotation logic to always use heading angle
- Remove conditional behavior based on map rotation setting
- Ensure consistent aircraft marker orientation in both map rotation modes

## Changes
- Modified `map_screen.dart` to remove conditional rotation logic
- Aircraft marker now always rotates by heading angle regardless of map rotation setting
- This ensures proper behavior in both rotation modes:
  - When map rotation is enabled: marker rotation counteracts map rotation (always points up)
  - When map rotation is disabled: marker shows actual heading direction

## Test plan
- [x] Code compiles without errors or warnings
- [x] Flutter analyzer passes (no new issues introduced)
- [x] iOS build completes successfully
- [ ] Manual testing with map rotation enabled/disabled to verify marker behavior

Fixes #78

🤖 Generated with [Claude Code](https://claude.ai/code)