### PR TITLE
Fix marker label sizing and wind information positioning

### DIFF
--- a/lib/widgets/metar_overlay.dart
+++ b/lib/widgets/metar_overlay.dart
@@ -82,13 +82,13 @@ class MetarOverlay extends StatelessWidget {
     return Marker(
       point: airport.position,
       width: 120, // Width for wind label
-      height: 80, // Height to position above airport marker
+      height: 140, // Further increased height to position much higher above airport marker
       child: GestureDetector(
         onTap: () => onAirportTap?.call(airport),
         child: Align(
           alignment: Alignment.bottomCenter, // Align to bottom so it appears above marker
           child: Padding(
-            padding: EdgeInsets.only(bottom: 30), // Offset to position above airport marker
+            padding: EdgeInsets.only(bottom: 90), // Significantly increased offset to position much higher above airport marker
             child: Row(
               mainAxisSize: MainAxisSize.min,
               mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/widgets/navaid_marker.dart
+++ b/lib/widgets/navaid_marker.dart
@@ -32,7 +32,7 @@ class NavaidMarker extends StatelessWidget {
 
     // Determine if label should be shown based on zoom
     final shouldShowLabel = mapZoom >= 11;
-    final fontSize = mapZoom >= 12 ? 11.0 : 9.0;
+    final fontSize = mapZoom >= 12 ? 8.25 : 6.75;
 
     return GestureDetector(
       onTap: onTap,

--- a/lib/widgets/optimized_marker_layer.dart
+++ b/lib/widgets/optimized_marker_layer.dart
@@ -381,9 +381,9 @@ class OptimizedNavaidMarkersLayer extends StatelessWidget {
     // Calculate marker dimensions with label space
     // Labels are shown at zoom level 11 and above for navaids
     final showLabelNow = showLabels && currentZoom >= 11;
-    final labelHeight = showLabelNow ? 30.0 : 0; // Extra height for label (increased from 25)
+    final labelHeight = showLabelNow ? 22.5 : 0; // Extra height for label (reduced by 25%)
     final markerHeight = dynamicMarkerSize + labelHeight;
-    final markerWidth = showLabelNow ? 80.0 : dynamicMarkerSize; // Wider for label text
+    final markerWidth = showLabelNow ? 60.0 : dynamicMarkerSize; // Reduced width for smaller label text
 
     return OptimizedMarkerLayer(
       markerPositions: positions,


### PR DESCRIPTION
## Summary
- Reduced navigation marker labels by 25% for better map clarity
- Repositioned wind information display to prevent overlap with other map elements

## Changes Made

### Navigation Marker Label Improvements
- **Font size**: Reduced from 11.0/9.0 to 8.25/6.75 (25% smaller)
- **Label container height**: Reduced from 30 to 22.5 pixels
- **Label width**: Reduced from 80 to 60 pixels
- These changes improve map readability by preventing label overlap at higher marker densities

### Wind Information Positioning
- **Marker height**: Increased from 80 to 140 pixels
- **Bottom padding**: Increased from 30 to 90 pixels
- Wind information now appears significantly higher above airport markers, preventing overlap with runway visualizations and other map information

## Test Plan
- [ ] Verify navigation marker labels appear 25% smaller at all zoom levels
- [ ] Confirm wind information displays above airport markers without overlapping
- [ ] Test at various zoom levels to ensure proper scaling
- [ ] Check that touch targets remain accessible despite smaller labels

🤖 Generated with [Claude Code](https://claude.ai/code)