### PR TITLE
feat: add interactive chart-to-map marker visualization and UI improvements

### DIFF
--- a/lib/constants/flight_detail_constants.dart
+++ b/lib/constants/flight_detail_constants.dart
@@ -18,7 +18,7 @@ class FlightDetailConstants {
   static const double markerBorderWidth = 2.0;
   
   // Animation and timing
-  static const int touchDebounceMilliseconds = 16; // ~60fps
+  static const int touchDebounceMilliseconds = 0; // No debounce for immediate response
   static const int mapFitDelayMilliseconds = 300;
   
   // Divider styling

--- a/lib/constants/flight_detail_constants.dart
+++ b/lib/constants/flight_detail_constants.dart
@@ -1,0 +1,31 @@
+/// Constants for the Flight Detail Screen
+class FlightDetailConstants {
+  // Drag sensitivity for resizing map/chart panels
+  static const double dragSensitivity = 2.5;
+  
+  // Map height fraction limits (percentage of screen)
+  static const double minMapHeightFraction = 0.15;
+  static const double maxMapHeightFraction = 0.85;
+  static const double defaultMapHeightFraction = 0.5;
+  
+  // Layout dimensions
+  static const double dividerHeight = 16.0;
+  static const double minPanelHeight = 60.0;
+  
+  // Marker dimensions
+  static const double markerSize = 24.0;
+  static const double markerIconSize = 8.0;
+  static const double markerBorderWidth = 2.0;
+  
+  // Animation and timing
+  static const int touchDebounceMilliseconds = 16; // ~60fps
+  static const int mapFitDelayMilliseconds = 300;
+  
+  // Divider styling
+  static const double dividerBorderWidth = 0.5;
+  static const double dividerHandleRadius = 12.0;
+  static const double dividerHandlePadding = 12.0;
+  static const double dividerHandleIconSize = 16.0;
+  static const double dividerHandleBarWidth = 3.0;
+  static const double dividerHandleBarHeight = 10.0;
+}

--- a/lib/screens/flight_detail_screen.dart
+++ b/lib/screens/flight_detail_screen.dart
@@ -37,23 +37,34 @@ class _FlightDetailScreenState extends State<FlightDetailScreen> {
     });
   }
 
-  /// Handles chart point selection with debouncing to improve performance.
-  /// Limits updates to approximately 60fps to prevent excessive re-renders.
+  /// Handles chart point selection with optional debouncing.
+  /// When debounce is 0, updates are immediate for smooth interaction.
   void _onChartPointSelected(int index) {
-    // Cancel any existing timer to debounce rapid touch events
+    // Cancel any existing timer
     _touchDebounce?.cancel();
-    _touchDebounce = Timer(
-      const Duration(milliseconds: FlightDetailConstants.touchDebounceMilliseconds),
-      () {
-        if (mounted) {
-          setState(() {
-            _selectedChartPointIndex = index;
-          });
-          // Update the map to show the marker at this point
-          _mapKey.currentState?.showMarkerAtIndex(index);
-        }
-      },
-    );
+    
+    if (FlightDetailConstants.touchDebounceMilliseconds == 0) {
+      // Immediate update for smooth interaction
+      if (mounted) {
+        setState(() {
+          _selectedChartPointIndex = index;
+        });
+        _mapKey.currentState?.showMarkerAtIndex(index);
+      }
+    } else {
+      // Debounced update for performance optimization
+      _touchDebounce = Timer(
+        const Duration(milliseconds: FlightDetailConstants.touchDebounceMilliseconds),
+        () {
+          if (mounted) {
+            setState(() {
+              _selectedChartPointIndex = index;
+            });
+            _mapKey.currentState?.showMarkerAtIndex(index);
+          }
+        },
+      );
+    }
   }
 
   /// Updates the map/chart split ratio based on vertical drag gesture.

--- a/lib/screens/logbook/logbook_entries_tab.dart
+++ b/lib/screens/logbook/logbook_entries_tab.dart
@@ -123,11 +123,14 @@ class _LogBookEntryTile extends StatelessWidget {
                   color: AppColors.secondaryTextColor,
                 ),
                 const SizedBox(width: 4),
-                Text(
-                  dateFormat.format(entry.dateTimeStarted),
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: AppColors.secondaryTextColor,
+                Flexible(
+                  child: Text(
+                    dateFormat.format(entry.dateTimeStarted),
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: AppColors.secondaryTextColor,
+                    ),
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
                 const SizedBox(width: 16),
@@ -137,11 +140,14 @@ class _LogBookEntryTile extends StatelessWidget {
                   color: AppColors.secondaryTextColor,
                 ),
                 const SizedBox(width: 4),
-                Text(
-                  '${timeFormat.format(entry.dateTimeStarted)} - ${timeFormat.format(entry.dateTimeFinished)}',
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: AppColors.secondaryTextColor,
+                Flexible(
+                  child: Text(
+                    '${timeFormat.format(entry.dateTimeStarted)} - ${timeFormat.format(entry.dateTimeFinished)}',
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: AppColors.secondaryTextColor,
+                    ),
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
               ],
@@ -156,22 +162,16 @@ class _LogBookEntryTile extends StatelessWidget {
                     color: AppColors.secondaryTextColor,
                   ),
                   const SizedBox(width: 4),
-                  Text(
-                    entry.aircraftType!,
-                    style: TextStyle(
-                      fontSize: 13,
-                      color: AppColors.primaryTextColor,
-                    ),
-                  ),
-                  if (entry.aircraftIdentification != null) ...[
-                    Text(
-                      ' (${entry.aircraftIdentification})',
+                  Flexible(
+                    child: Text(
+                      entry.aircraftType! + (entry.aircraftIdentification != null ? ' (${entry.aircraftIdentification})' : ''),
                       style: TextStyle(
                         fontSize: 13,
-                        color: AppColors.secondaryTextColor,
+                        color: AppColors.primaryTextColor,
                       ),
+                      overflow: TextOverflow.ellipsis,
                     ),
-                  ],
+                  ),
                   const SizedBox(width: 16),
                 ],
                 if (entry.flightCondition != null) ...[

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -650,32 +650,46 @@ class MapScreenState extends State<MapScreen>
       final flightPlans = _flightPlanService.savedFlightPlans;
       if (flightPlans.isEmpty) return;
       
-      // Show progress indicator
+      // Show non-modal notification at the bottom
       if (mounted) {
-        showDialog(
-          context: context,
-          barrierDismissible: false,
-          builder: (context) => AlertDialog(
-            shape: RoundedRectangleBorder(
-              borderRadius: AppTheme.dialogRadius,
-            ),
-            content: const Row(
-              children: [
-                CircularProgressIndicator(),
-                SizedBox(width: 16),
-                Expanded(child: Text('Checking flight plan map tiles...')),
-              ],
-            ),
+        ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Row(
+            children: const [
+              SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                ),
+              ),
+              SizedBox(width: 16),
+              Flexible(
+                child: Text(
+                  'Checking flight plan map tiles...',
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
           ),
-        );
+          backgroundColor: AppColors.sectionBackgroundColor.withAlpha(230),
+          duration: const Duration(seconds: 5),
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+          margin: const EdgeInsets.all(16),
+        ),
+      );
       }
       
       // Validate all flight plans
       final validationResults = await _tileDownloadService!.validateAllFlightPlans(flightPlans);
       
-      // Close progress dialog
+      // Hide the notification
       if (mounted) {
-        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).hideCurrentSnackBar();
       }
       
       // If there are missing tiles, show dialog
@@ -683,9 +697,9 @@ class MapScreenState extends State<MapScreen>
         await _showMissingTilesDialog(validationResults);
       }
     } catch (e) {
-      // Close progress dialog if still showing
-      if (mounted && Navigator.canPop(context)) {
-        Navigator.of(context).pop();
+      // Hide the notification if still showing
+      if (mounted) {
+        ScaffoldMessenger.of(context).hideCurrentSnackBar();
       }
     }
   }

--- a/lib/services/offline_tile_provider.dart
+++ b/lib/services/offline_tile_provider.dart
@@ -93,7 +93,7 @@ class OfflineTileImageProvider extends ImageProvider<OfflineTileImageProvider> {
                 'User-Agent': userAgentPackageName!,
             },
           )
-          .timeout(const Duration(seconds: 10));
+          .timeout(const Duration(seconds: 5));
 
       if (response.statusCode == 200) {
         final bytes = response.bodyBytes;
@@ -107,9 +107,14 @@ class OfflineTileImageProvider extends ImageProvider<OfflineTileImageProvider> {
         throw Exception('HTTP ${response.statusCode}');
       }
     } catch (e) {
-      logger.w(
-        '⚠️ Failed to load tile ${coordinates.z}/${coordinates.x}/${coordinates.y}: $e',
-      );
+      // Log the error but don't spam the console for timeouts
+      if (e.toString().contains('TimeoutException')) {
+        // Silent fail for timeouts - map will show blank tile
+      } else {
+        logger.w(
+          '⚠️ Failed to load tile ${coordinates.z}/${coordinates.x}/${coordinates.y}: $e',
+        );
+      }
 
       // Return a placeholder tile or rethrow the error
       throw Exception('Failed to load map tile: $e');

--- a/lib/widgets/altitude_vertical_speed_chart.dart
+++ b/lib/widgets/altitude_vertical_speed_chart.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:provider/provider.dart';
+import '../constants/app_colors.dart';
+import '../services/settings_service.dart';
 
 class AltitudeVerticalSpeedChart extends StatelessWidget {
   final List<double> altitudeData;
@@ -7,6 +10,8 @@ class AltitudeVerticalSpeedChart extends StatelessWidget {
   final double? currentAltitude;
   final double? minAltitude;
   final double? maxAltitude;
+  final DateTime? startTimeZulu;
+  final Function(int)? onPointSelected;
 
   const AltitudeVerticalSpeedChart({
     super.key,
@@ -15,94 +20,131 @@ class AltitudeVerticalSpeedChart extends StatelessWidget {
     this.currentAltitude,
     this.minAltitude,
     this.maxAltitude,
+    this.startTimeZulu,
+    this.onPointSelected,
   });
 
   @override
   Widget build(BuildContext context) {
     if (altitudeData.isEmpty) {
-      return const Center(
+      return Center(
         child: Text(
           'No altitude data available\nStart tracking to see altitude changes',
           textAlign: TextAlign.center,
-          style: TextStyle(color: Colors.grey),
+          style: TextStyle(color: AppColors.tertiaryTextColor),
         ),
       );
     }
 
-    final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
+    return Consumer<SettingsService>(
+      builder: (context, settings, child) {
+        final isMetric = settings.units == 'metric';
+        
+        // Convert altitude data to appropriate units
+        final displayAltitudes = isMetric
+            ? altitudeData // meters
+            : altitudeData.map((a) => a * 3.28084).toList(); // feet
+        
+        final altitudeUnit = isMetric ? 'm' : 'ft';
+        final vsUnit = isMetric ? 'm/s' : 'ft/min';
+        
+        // Convert vertical speeds to appropriate units
+        final vsData = verticalSpeedData.isNotEmpty
+            ? verticalSpeedData
+            : List.filled(altitudeData.length, 0.0);
+        
+        final displayVS = isMetric
+            ? vsData // m/s
+            : vsData.map((vs) => vs * 196.85).toList(); // ft/min
+        
+        // Calculate min and max for altitude Y axis
+        final altConversionFactor = isMetric ? 1.0 : 3.28084;
+        final padding = isMetric ? 50.0 : 150.0;
+        
+        final minAltY = minAltitude != null
+            ? minAltitude! * altConversionFactor - padding
+            : (displayAltitudes.isNotEmpty
+                ? displayAltitudes.reduce((a, b) => a < b ? a : b) - padding
+                : 0.0);
+        
+        final maxAltY = maxAltitude != null
+            ? maxAltitude! * altConversionFactor + padding
+            : (displayAltitudes.isNotEmpty
+                ? displayAltitudes.reduce((a, b) => a > b ? a : b) + padding
+                : 1000.0);
+        
+        // Calculate min and max for vertical speed Y axis
+        final vsPadding = isMetric ? 0.5 : 50.0;
+        final minVS = displayVS.reduce((a, b) => a < b ? a : b) - vsPadding;
+        final maxVS = displayVS.reduce((a, b) => a > b ? a : b) + vsPadding;
 
-    // Calculate min and max for altitude Y axis
-    final minAltY =
-        minAltitude ??
-        (altitudeData.isNotEmpty
-            ? altitudeData.reduce((a, b) => a < b ? a : b) - 50
-            : 0);
-    final maxAltY =
-        maxAltitude ??
-        (altitudeData.isNotEmpty
-            ? altitudeData.reduce((a, b) => a > b ? a : b) + 50
-            : 1000);
-
-    // Calculate min and max for vertical speed Y axis (in m/s)
-    final vsData = verticalSpeedData.isNotEmpty
-        ? verticalSpeedData
-        : List.filled(altitudeData.length, 0.0);
-    final minVS = vsData.reduce((a, b) => a < b ? a : b) - 0.5;
-    final maxVS = vsData.reduce((a, b) => a > b ? a : b) + 0.5;
-
-    return Container(
-      padding: const EdgeInsets.all(16),
-      height: 300,
+        return Container(
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
+      height: 320,
       child: LineChart(
         LineChartData(
           gridData: FlGridData(
             show: true,
             drawVerticalLine: false,
             getDrawingHorizontalLine: (value) => FlLine(
-              color: isDark ? Colors.grey[800]! : Colors.grey[300]!,
+              color: AppColors.sectionBorderColor.withAlpha(76),
               strokeWidth: 1,
             ),
           ),
           titlesData: FlTitlesData(
             leftTitles: AxisTitles(
-              axisNameWidget: const Text(
-                'Altitude (m)',
-                style: TextStyle(fontSize: 12),
+              axisNameWidget: Text(
+                'Altitude ($altitudeUnit)',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: AppColors.secondaryTextColor,
+                ),
               ),
               sideTitles: SideTitles(
                 showTitles: true,
-                reservedSize: 50,
+                reservedSize: 60,
                 getTitlesWidget: (value, meta) => Text(
                   value.toInt().toString(),
-                  style: const TextStyle(fontSize: 10),
+                  style: TextStyle(
+                    fontSize: 10,
+                    color: AppColors.secondaryTextColor,
+                  ),
                 ),
               ),
             ),
             rightTitles: AxisTitles(
-              axisNameWidget: const Text(
-                'V/S (m/s)',
-                style: TextStyle(fontSize: 12),
+              axisNameWidget: Text(
+                'V/S ($vsUnit)',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: AppColors.successColor,
+                ),
               ),
               sideTitles: SideTitles(
                 showTitles: true,
-                reservedSize: 50,
+                reservedSize: 60,
                 getTitlesWidget: (value, meta) {
                   // Map the right axis to vertical speed range
                   final vsValue =
                       minVS +
                       (value - minAltY) * (maxVS - minVS) / (maxAltY - minAltY);
                   return Text(
-                    vsValue.toStringAsFixed(1),
-                    style: const TextStyle(fontSize: 10, color: Colors.green),
+                    isMetric ? vsValue.toStringAsFixed(1) : vsValue.toStringAsFixed(0),
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: AppColors.successColor,
+                    ),
                   );
                 },
               ),
             ),
             bottomTitles: AxisTitles(
-              axisNameWidget: const Text(
+              axisNameWidget: Text(
                 'Time (minutes)',
-                style: TextStyle(fontSize: 12),
+                style: TextStyle(
+                  fontSize: 11,
+                  color: AppColors.secondaryTextColor,
+                ),
               ),
               sideTitles: SideTitles(
                 showTitles: true,
@@ -110,10 +152,26 @@ class AltitudeVerticalSpeedChart extends StatelessWidget {
                     ? altitudeData.length / 5
                     : 1,
                 getTitlesWidget: (value, meta) {
-                  final minutes = value.toInt();
+                  final index = value.toInt();
+                  // Assuming each data point is 1 second
+                  final totalSeconds = index;
+                  final minutes = totalSeconds ~/ 60;
+                  final seconds = totalSeconds % 60;
+                  
+                  // Show time in M:SS format for first few minutes, then just minutes
+                  String timeLabel;
+                  if (minutes < 5 && altitudeData.length < 600) {
+                    timeLabel = '$minutes:${seconds.toString().padLeft(2, '0')}';
+                  } else {
+                    timeLabel = '${minutes}m';
+                  }
+                  
                   return Text(
-                    minutes.toString(),
-                    style: const TextStyle(fontSize: 10),
+                    timeLabel,
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: AppColors.secondaryTextColor,
+                    ),
                   );
                 },
               ),
@@ -130,24 +188,23 @@ class AltitudeVerticalSpeedChart extends StatelessWidget {
           lineBarsData: [
             // Altitude line
             LineChartBarData(
-              spots: altitudeData.asMap().entries.map((entry) {
+              spots: displayAltitudes.asMap().entries.map((entry) {
                 return FlSpot(entry.key.toDouble(), entry.value);
               }).toList(),
               isCurved: true,
               preventCurveOverShooting: true,
-              color: isDark ? Colors.blue[300] : Colors.blue[600],
+              color: AppColors.primaryAccent,
               barWidth: 2,
               isStrokeCapRound: true,
               dotData: const FlDotData(show: false),
               belowBarData: BarAreaData(
                 show: true,
-                color: (isDark ? Colors.blue[300] : Colors.blue[600])!
-                    .withValues(alpha: 0.15),
+                color: AppColors.primaryAccent.withAlpha(38),
               ),
             ),
             // Vertical speed line (mapped to altitude scale)
             LineChartBarData(
-              spots: vsData.asMap().entries.map((entry) {
+              spots: displayVS.asMap().entries.map((entry) {
                 // Map vertical speed to altitude scale for display
                 final mappedValue =
                     minAltY +
@@ -158,7 +215,7 @@ class AltitudeVerticalSpeedChart extends StatelessWidget {
               }).toList(),
               isCurved: true,
               preventCurveOverShooting: true,
-              color: Colors.green,
+              color: AppColors.successColor,
               barWidth: 2,
               isStrokeCapRound: true,
               dotData: const FlDotData(show: false),
@@ -166,38 +223,162 @@ class AltitudeVerticalSpeedChart extends StatelessWidget {
             ),
           ],
           lineTouchData: LineTouchData(
+            touchCallback: (FlTouchEvent event, LineTouchResponse? response) {
+              // Handle all touch events that have a response with line bar spots
+              if (response != null && response.lineBarSpots != null && response.lineBarSpots!.isNotEmpty) {
+                final spotIndex = response.lineBarSpots!.first.x.toInt();
+                // Call for any touch event with valid response
+                onPointSelected?.call(spotIndex);
+              }
+            },
             touchTooltipData: LineTouchTooltipData(
-              tooltipBorder: const BorderSide(color: Colors.transparent),
+              getTooltipColor: (touchedSpots) => AppColors.sectionBackgroundColor.withAlpha(230),
+              tooltipBorderRadius: BorderRadius.circular(4),
+              tooltipBorder: BorderSide(color: AppColors.primaryTextColor.withAlpha(153), width: 0.5),
+              tooltipPadding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+              tooltipMargin: 8,
+              maxContentWidth: 120,
+              fitInsideHorizontally: true,
+              fitInsideVertically: true,
+              showOnTopOfTheChartBoxArea: false,
               getTooltipItems: (List<LineBarSpot> touchedBarSpots) {
-                return touchedBarSpots.map((barSpot) {
-                  final flSpot = barSpot;
-                  if (barSpot.barIndex == 0) {
-                    // Altitude
-                    return LineTooltipItem(
-                      '${flSpot.y.toStringAsFixed(0)} m',
-                      const TextStyle(
-                        color: Colors.white,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    );
+                if (touchedBarSpots.isEmpty) return [];
+                
+                // Calculate actual time once for all touched spots
+                final firstSpot = touchedBarSpots.first;
+                String timeString;
+                if (startTimeZulu != null) {
+                  // Add seconds to start time to get actual timestamp
+                  final actualTime = startTimeZulu!.add(Duration(seconds: firstSpot.x.toInt()));
+                  timeString = '${actualTime.hour.toString().padLeft(2, '0')}:${actualTime.minute.toString().padLeft(2, '0')}:${actualTime.second.toString().padLeft(2, '0')}';
+                } else {
+                  // Fallback to elapsed time if start time not provided
+                  final totalSeconds = firstSpot.x.toInt();
+                  timeString = '${(totalSeconds ~/ 60).toString().padLeft(2, '0')}:${(totalSeconds % 60).toString().padLeft(2, '0')}';
+                }
+                
+                // Return one tooltip item per touched spot, but only show time on the first one
+                return touchedBarSpots.asMap().entries.map((entry) {
+                  final index = entry.key;
+                  final barSpot = entry.value;
+                  
+                  if (index == 0) {
+                    // First item shows time and value
+                    if (barSpot.barIndex == 0) {
+                      // Altitude
+                      return LineTooltipItem(
+                        '',
+                        const TextStyle(),
+                        children: [
+                          TextSpan(
+                            text: '$timeString Z',
+                            style: TextStyle(
+                              color: AppColors.warningColor,
+                              fontSize: 9,
+                              fontWeight: FontWeight.w600,
+                              height: 1.2,
+                            ),
+                          ),
+                          TextSpan(
+                            text: '\n${barSpot.y.toStringAsFixed(0)} $altitudeUnit',
+                            style: TextStyle(
+                              color: AppColors.primaryAccent,
+                              fontSize: 9,
+                              height: 1.2,
+                            ),
+                          ),
+                        ],
+                      );
+                    } else {
+                      // Vertical speed
+                      final vsValue = displayVS[barSpot.x.toInt()];
+                      final vsFormatted = isMetric 
+                          ? '${vsValue.toStringAsFixed(1)} m/s'
+                          : '${vsValue.toStringAsFixed(0)} ft/min';
+                      return LineTooltipItem(
+                        '',
+                        const TextStyle(),
+                        children: [
+                          TextSpan(
+                            text: '$timeString Z',
+                            style: TextStyle(
+                              color: AppColors.warningColor,
+                              fontSize: 9,
+                              fontWeight: FontWeight.w600,
+                              height: 1.2,
+                            ),
+                          ),
+                          TextSpan(
+                            text: '\nV/S: $vsFormatted',
+                            style: TextStyle(
+                              color: AppColors.successColor,
+                              fontSize: 9,
+                              height: 1.2,
+                            ),
+                          ),
+                        ],
+                      );
+                    }
                   } else {
-                    // Vertical speed - convert back from mapped value
-                    final vsValue = vsData[flSpot.x.toInt()];
-                    return LineTooltipItem(
-                      'V/S: ${vsValue.toStringAsFixed(1)} m/s',
-                      const TextStyle(
-                        color: Colors.green,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    );
+                    // Subsequent items only show value
+                    if (barSpot.barIndex == 0) {
+                      // Altitude
+                      return LineTooltipItem(
+                        '${barSpot.y.toStringAsFixed(0)} $altitudeUnit',
+                        TextStyle(
+                          color: AppColors.primaryAccent,
+                          fontSize: 9,
+                          height: 1.2,
+                        ),
+                      );
+                    } else {
+                      // Vertical speed
+                      final vsValue = displayVS[barSpot.x.toInt()];
+                      final vsFormatted = isMetric 
+                          ? '${vsValue.toStringAsFixed(1)} m/s'
+                          : '${vsValue.toStringAsFixed(0)} ft/min';
+                      return LineTooltipItem(
+                        'V/S: $vsFormatted',
+                        TextStyle(
+                          color: AppColors.successColor,
+                          fontSize: 9,
+                          height: 1.2,
+                        ),
+                      );
+                    }
                   }
                 }).toList();
               },
             ),
             handleBuiltInTouches: true,
+            getTouchedSpotIndicator: (LineChartBarData barData, List<int> spotIndexes) {
+              return spotIndexes.map((index) {
+                final color = barData.color ?? AppColors.primaryAccent;
+                return TouchedSpotIndicatorData(
+                  FlLine(
+                    color: color.withAlpha(51),
+                    strokeWidth: 1,
+                    dashArray: [3, 3],
+                  ),
+                  FlDotData(
+                    show: true,
+                    getDotPainter: (spot, percent, barData, index) {
+                      return FlDotCirclePainter(
+                        radius: 3,
+                        color: color,
+                        strokeWidth: 1.5,
+                        strokeColor: AppColors.primaryTextColor,
+                      );
+                    },
+                  ),
+                );
+              }).toList();
+            },
           ),
         ),
       ),
+        );
+      },
     );
   }
 }

--- a/lib/widgets/flight_detail/flight_detail_map.dart
+++ b/lib/widgets/flight_detail/flight_detail_map.dart
@@ -3,6 +3,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:flutter_map/flutter_map.dart';
 import '../../models/flight.dart';
 import '../../models/moving_segment.dart';
+import '../../constants/flight_detail_constants.dart';
 
 class FlightDetailMap extends StatefulWidget {
   final Flight flight;
@@ -42,7 +43,9 @@ class FlightDetailMapState extends State<FlightDetailMap> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         // Small delay to ensure map is fully initialized
-        Future.delayed(const Duration(milliseconds: 300), () {
+        Future.delayed(
+          const Duration(milliseconds: FlightDetailConstants.mapFitDelayMilliseconds),
+          () {
           if (mounted) {
             _fitBoundsWhenReady();
           }
@@ -57,6 +60,9 @@ class FlightDetailMapState extends State<FlightDetailMap> {
     super.dispose();
   }
 
+  /// Calculates the geographical bounds of the flight path.
+  /// Adds 10% padding to ensure the entire flight track is visible
+  /// with some margin around the edges.
   void _calculateBounds() {
     if (widget.flight.path.isEmpty) return;
 
@@ -85,6 +91,9 @@ class FlightDetailMapState extends State<FlightDetailMap> {
     );
   }
 
+  /// Attempts to fit the map view to show the entire flight path.
+  /// Includes retry logic in case the map controller isn't ready yet.
+  /// Also triggers a micro zoom adjustment to force tile loading.
   void _fitBoundsWhenReady() {
     if (_flightBounds == null || !mounted) return;
 
@@ -120,7 +129,9 @@ class FlightDetailMapState extends State<FlightDetailMap> {
     }
   }
 
-  // Public method to fit map to track, called when resizing ends
+  /// Fits the map view to display the entire flight track.
+  /// This is called after the user finishes resizing the map panel
+  /// to ensure the flight path remains centered and visible.
   void fitMapToTrack() {
     if (_flightBounds == null || !mounted) return;
     
@@ -136,7 +147,13 @@ class FlightDetailMapState extends State<FlightDetailMap> {
     }
   }
 
-  // Public method to show a marker at a specific data point index
+  /// Shows a marker on the map at the GPS location corresponding to
+  /// the given data point index from the flight path.
+  /// 
+  /// [index] - The index in the flight path array (0-based)
+  /// 
+  /// This method is called when users interact with charts to visualize
+  /// the selected point's location on the map.
   void showMarkerAtIndex(int index) {
     if (!mounted || widget.flight.path.isEmpty) return;
     
@@ -320,15 +337,15 @@ class FlightDetailMapState extends State<FlightDetailMap> {
                     if (_selectedChartPoint != null)
                       Marker(
                         point: _selectedChartPoint!,
-                        width: 24,
-                        height: 24,
+                        width: FlightDetailConstants.markerSize,
+                        height: FlightDetailConstants.markerSize,
                         child: Container(
                           decoration: BoxDecoration(
                             shape: BoxShape.circle,
                             color: Colors.deepOrange,
                             border: Border.all(
                               color: Colors.white,
-                              width: 2,
+                              width: FlightDetailConstants.markerBorderWidth,
                             ),
                             boxShadow: [
                               BoxShadow(
@@ -342,7 +359,7 @@ class FlightDetailMapState extends State<FlightDetailMap> {
                             child: Icon(
                               Icons.circle,
                               color: Colors.white,
-                              size: 8,
+                              size: FlightDetailConstants.markerIconSize,
                             ),
                           ),
                         ),

--- a/lib/widgets/flight_detail/flight_info_tab.dart
+++ b/lib/widgets/flight_detail/flight_info_tab.dart
@@ -5,6 +5,7 @@ import '../../models/flight.dart';
 import '../../models/moving_segment.dart';
 import '../../services/settings_service.dart';
 import '../../constants/app_theme.dart';
+import '../../constants/app_colors.dart';
 
 class FlightInfoTab extends StatelessWidget {
   final Flight flight;
@@ -53,12 +54,14 @@ class FlightInfoTab extends StatelessWidget {
             children: [
               Text(
                 'Flight Summary',
-                style: Theme.of(context).textTheme.titleLarge,
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  color: AppColors.primaryTextColor,
+                ),
               ),
               Text(
                 _formatDuration(flight.duration),
                 style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                  color: Theme.of(context).colorScheme.primary,
+                  color: AppColors.primaryAccent,
                 ),
               ),
             ],
@@ -105,7 +108,9 @@ class FlightInfoTab extends StatelessWidget {
                 children: [
                   Text(
                     'Flight Details',
-                    style: Theme.of(context).textTheme.titleMedium,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: AppColors.primaryTextColor,
+                    ),
                   ),
                   const SizedBox(height: 12),
                   Wrap(
@@ -181,12 +186,10 @@ class FlightInfoTab extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(16.0),
       decoration: BoxDecoration(
-        color: Theme.of(
-          context,
-        ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+        color: AppColors.backgroundColor,
         borderRadius: AppTheme.extraLargeRadius,
         border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+          color: AppColors.sectionBorderColor,
         ),
       ),
       child: Column(
@@ -196,7 +199,7 @@ class FlightInfoTab extends StatelessWidget {
             children: [
               Icon(
                 Icons.schedule,
-                color: Theme.of(context).colorScheme.primary,
+                color: AppColors.primaryAccent,
                 size: 20,
               ),
               const SizedBox(width: 8),
@@ -204,7 +207,7 @@ class FlightInfoTab extends StatelessWidget {
                 child: Text(
                   'Time Tracking (Zulu Times)',
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    color: Theme.of(context).colorScheme.primary,
+                    color: AppColors.primaryAccent,
                   ),
                   overflow: TextOverflow.ellipsis,
                 ),
@@ -258,13 +261,14 @@ class FlightInfoTab extends StatelessWidget {
                   Text(
                     'Total Recording',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      color: AppColors.secondaryTextColor,
                     ),
                   ),
                   Text(
                     _formatDuration(flight.totalRecordingTime),
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                       fontWeight: FontWeight.bold,
+                      color: AppColors.primaryTextColor,
                     ),
                   ),
                 ],
@@ -275,14 +279,14 @@ class FlightInfoTab extends StatelessWidget {
                   Text(
                     'Total Moving',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      color: AppColors.secondaryTextColor,
                     ),
                   ),
                   Text(
                     _formatDuration(flight.movingTime),
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                       fontWeight: FontWeight.bold,
-                      color: Theme.of(context).colorScheme.primary,
+                      color: AppColors.primaryAccent,
                     ),
                   ),
                 ],
@@ -298,12 +302,10 @@ class FlightInfoTab extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(16.0),
       decoration: BoxDecoration(
-        color: Theme.of(
-          context,
-        ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+        color: AppColors.backgroundColor,
         borderRadius: AppTheme.extraLargeRadius,
         border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+          color: AppColors.sectionBorderColor,
         ),
       ),
       child: Column(
@@ -313,7 +315,7 @@ class FlightInfoTab extends StatelessWidget {
             children: [
               Icon(
                 Icons.timeline,
-                color: Theme.of(context).colorScheme.primary,
+                color: AppColors.primaryAccent,
                 size: 20,
               ),
               const SizedBox(width: 8),
@@ -321,7 +323,7 @@ class FlightInfoTab extends StatelessWidget {
                 child: Text(
                   'Moving Segments (${flight.movingSegments.length})',
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    color: Theme.of(context).colorScheme.primary,
+                    color: AppColors.primaryAccent,
                   ),
                   overflow: TextOverflow.ellipsis,
                 ),
@@ -342,15 +344,13 @@ class FlightInfoTab extends StatelessWidget {
                   padding: const EdgeInsets.all(12.0),
                   decoration: BoxDecoration(
                     color: selectedSegment == segment
-                        ? Theme.of(context).colorScheme.primaryContainer
-                        : Theme.of(context).colorScheme.surface,
+                        ? AppColors.sectionBackgroundColor
+                        : AppColors.backgroundColor,
                     borderRadius: AppTheme.defaultRadius,
                     border: Border.all(
                       color: selectedSegment == segment
-                          ? Theme.of(context).colorScheme.primary
-                          : Theme.of(
-                              context,
-                            ).colorScheme.outline.withValues(alpha: 0.1),
+                          ? AppColors.primaryAccent
+                          : AppColors.sectionBorderColor,
                     ),
                   ),
                   child: Column(
@@ -362,13 +362,16 @@ class FlightInfoTab extends StatelessWidget {
                           Text(
                             'Segment ${index + 1}',
                             style: Theme.of(context).textTheme.bodyMedium
-                                ?.copyWith(fontWeight: FontWeight.bold),
+                                ?.copyWith(
+                                  fontWeight: FontWeight.bold,
+                                  color: AppColors.primaryTextColor,
+                                ),
                           ),
                           Text(
                             segment.formattedDuration,
                             style: Theme.of(context).textTheme.bodyMedium
                                 ?.copyWith(
-                                  color: Theme.of(context).colorScheme.primary,
+                                  color: AppColors.primaryAccent,
                                   fontWeight: FontWeight.bold,
                                 ),
                           ),
@@ -385,14 +388,14 @@ class FlightInfoTab extends StatelessWidget {
                                 'Started',
                                 style: Theme.of(context).textTheme.bodySmall
                                     ?.copyWith(
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.onSurfaceVariant,
+                                      color: AppColors.secondaryTextColor,
                                     ),
                               ),
                               Text(
                                 segment.startZuluFormatted,
-                                style: Theme.of(context).textTheme.bodySmall,
+                                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                  color: AppColors.primaryTextColor,
+                                ),
                               ),
                             ],
                           ),
@@ -403,14 +406,14 @@ class FlightInfoTab extends StatelessWidget {
                                 'Stopped',
                                 style: Theme.of(context).textTheme.bodySmall
                                     ?.copyWith(
-                                      color: Theme.of(
-                                        context,
-                                      ).colorScheme.onSurfaceVariant,
+                                      color: AppColors.secondaryTextColor,
                                     ),
                               ),
                               Text(
                                 segment.endZuluFormatted,
-                                style: Theme.of(context).textTheme.bodySmall,
+                                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                  color: AppColors.primaryTextColor,
+                                ),
                               ),
                             ],
                           ),
@@ -432,16 +435,14 @@ class FlightInfoTab extends StatelessWidget {
             Container(
               padding: const EdgeInsets.all(12.0),
               decoration: BoxDecoration(
-                color: Theme.of(
-                  context,
-                ).colorScheme.errorContainer.withValues(alpha: 0.3),
+                color: AppColors.errorColor.withAlpha(51), // 0.2 opacity
                 borderRadius: AppTheme.defaultRadius,
               ),
               child: Row(
                 children: [
                   Icon(
                     Icons.pause_circle,
-                    color: Theme.of(context).colorScheme.error,
+                    color: AppColors.errorColor,
                     size: 20,
                   ),
                   const SizedBox(width: 8),
@@ -449,7 +450,7 @@ class FlightInfoTab extends StatelessWidget {
                     child: Text(
                       '${flight.pausePoints.length} pause point${flight.pausePoints.length != 1 ? 's' : ''} recorded',
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context).colorScheme.onErrorContainer,
+                        color: AppColors.primaryTextColor,
                       ),
                       overflow: TextOverflow.ellipsis,
                     ),
@@ -585,14 +586,14 @@ class FlightInfoTab extends StatelessWidget {
           Icon(
             icon,
             size: 16,
-            color: Theme.of(context).colorScheme.onSurfaceVariant,
+            color: AppColors.secondaryTextColor,
           ),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
               label,
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                color: AppColors.secondaryTextColor,
               ),
             ),
           ),
@@ -601,6 +602,7 @@ class FlightInfoTab extends StatelessWidget {
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               fontFamily: 'monospace',
               fontWeight: FontWeight.bold,
+              color: AppColors.primaryTextColor,
             ),
           ),
         ],
@@ -618,10 +620,10 @@ class FlightInfoTab extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(8.0),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface,
+        color: AppColors.sectionBackgroundColor,
         borderRadius: AppTheme.defaultRadius,
         border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.1),
+          color: AppColors.sectionBorderColor,
         ),
       ),
       child: Row(
@@ -629,14 +631,14 @@ class FlightInfoTab extends StatelessWidget {
           Icon(
             icon,
             size: 18,
-            color: iconColor ?? Theme.of(context).colorScheme.onSurfaceVariant,
+            color: iconColor ?? AppColors.secondaryTextColor,
           ),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
               title,
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                color: AppColors.secondaryTextColor,
               ),
               overflow: TextOverflow.ellipsis,
             ),
@@ -646,7 +648,10 @@ class FlightInfoTab extends StatelessWidget {
               value,
               style: Theme.of(
                 context,
-              ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+              ).textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: AppColors.primaryTextColor,
+              ),
               overflow: TextOverflow.ellipsis,
               textAlign: TextAlign.end,
             ),
@@ -665,7 +670,7 @@ class FlightInfoTab extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(8.0),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        color: AppColors.sectionBackgroundColor,
         borderRadius: AppTheme.defaultRadius,
       ),
       child: Row(
@@ -676,7 +681,7 @@ class FlightInfoTab extends StatelessWidget {
             child: Icon(
               icon,
               size: 20,
-              color: Theme.of(context).colorScheme.primary,
+              color: AppColors.primaryAccent,
             ),
           ),
           const SizedBox(width: 8),
@@ -689,7 +694,7 @@ class FlightInfoTab extends StatelessWidget {
                 Text(
                   title,
                   style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    color: AppColors.secondaryTextColor,
                   ),
                   overflow: TextOverflow.ellipsis,
                   maxLines: 1,
@@ -699,7 +704,10 @@ class FlightInfoTab extends StatelessWidget {
                   value,
                   style: Theme.of(
                     context,
-                  ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+                  ).textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: AppColors.primaryTextColor,
+                  ),
                   overflow: TextOverflow.ellipsis,
                   maxLines: 2,
                 ),
@@ -715,10 +723,10 @@ class FlightInfoTab extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(16.0),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+        color: AppColors.backgroundColor,
         borderRadius: AppTheme.extraLargeRadius,
         border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+          color: AppColors.sectionBorderColor,
         ),
       ),
       child: Column(
@@ -728,14 +736,14 @@ class FlightInfoTab extends StatelessWidget {
             children: [
               Icon(
                 Icons.flight,
-                color: Theme.of(context).colorScheme.primary,
+                color: AppColors.primaryAccent,
                 size: 20,
               ),
               const SizedBox(width: 8),
               Text(
                 'Airports',
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: Theme.of(context).colorScheme.primary,
+                  color: AppColors.primaryAccent,
                 ),
               ),
             ],
@@ -749,7 +757,7 @@ class FlightInfoTab extends StatelessWidget {
                 Icon(
                   Icons.flight_takeoff,
                   size: 16,
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  color: AppColors.secondaryTextColor,
                 ),
                 const SizedBox(width: 8),
                 Expanded(
@@ -759,7 +767,7 @@ class FlightInfoTab extends StatelessWidget {
                       Text(
                         'Departure',
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          color: AppColors.secondaryTextColor,
                         ),
                       ),
                       Text(
@@ -767,6 +775,7 @@ class FlightInfoTab extends StatelessWidget {
                         style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                           fontWeight: FontWeight.bold,
                           fontFamily: 'monospace',
+                          color: AppColors.primaryTextColor,
                         ),
                       ),
                     ],
@@ -784,7 +793,7 @@ class FlightInfoTab extends StatelessWidget {
                 Icon(
                   Icons.flight_land,
                   size: 16,
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  color: AppColors.secondaryTextColor,
                 ),
                 const SizedBox(width: 8),
                 Expanded(
@@ -794,7 +803,7 @@ class FlightInfoTab extends StatelessWidget {
                       Text(
                         'Arrival',
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          color: AppColors.secondaryTextColor,
                         ),
                       ),
                       Text(
@@ -802,6 +811,7 @@ class FlightInfoTab extends StatelessWidget {
                         style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                           fontWeight: FontWeight.bold,
                           fontFamily: 'monospace',
+                          color: AppColors.primaryTextColor,
                         ),
                       ),
                     ],

--- a/lib/widgets/speed_chart.dart
+++ b/lib/widgets/speed_chart.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:provider/provider.dart';
+import '../constants/app_colors.dart';
+import '../services/settings_service.dart';
 
 class SpeedChart extends StatelessWidget {
   final List<double> speedData; // In m/s
   final double? currentSpeed;
   final double? minSpeed;
   final double? maxSpeed;
+  final DateTime? startTimeZulu;
+  final Function(int)? onPointSelected;
 
   const SpeedChart({
     super.key,
@@ -13,43 +18,52 @@ class SpeedChart extends StatelessWidget {
     this.currentSpeed,
     this.minSpeed,
     this.maxSpeed,
+    this.startTimeZulu,
+    this.onPointSelected,
   });
 
   @override
   Widget build(BuildContext context) {
     if (speedData.isEmpty) {
-      return const Center(
+      return Center(
         child: Text(
           'No speed data available\nStart tracking to see speed changes',
           textAlign: TextAlign.center,
-          style: TextStyle(color: Colors.grey),
+          style: TextStyle(color: AppColors.tertiaryTextColor),
         ),
       );
     }
 
-    final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
+    return Consumer<SettingsService>(
+      builder: (context, settings, child) {
+        final isMetric = settings.units == 'metric';
+        
+        // Convert m/s to appropriate unit for display
+        final displaySpeeds = isMetric
+            ? speedData.map((s) => s * 3.6).toList() // km/h
+            : speedData.map((s) => s * 2.23694).toList(); // mph
+        
+        final speedUnit = isMetric ? 'km/h' : 'mph';
+        
+        // Calculate min and max for the Y axis
+        final minY = 0.0; // Always start from 0 for speed
+        final conversionFactor = isMetric ? 3.6 : 2.23694;
+        final maxY = maxSpeed != null
+            ? maxSpeed! * conversionFactor * 1.1
+            : (displaySpeeds.isNotEmpty
+                  ? displaySpeeds.reduce((a, b) => a > b ? a : b) * 1.1
+                  : 100.0);
 
-    // Convert m/s to km/h for display
-    final speedsKmh = speedData.map((s) => s * 3.6).toList();
-    // Calculate min and max for the Y axis
-    final minY = 0.0; // Always start from 0 for speed
-    final maxY = maxSpeed != null
-        ? maxSpeed! * 3.6 * 1.1
-        : (speedsKmh.isNotEmpty
-              ? speedsKmh.reduce((a, b) => a > b ? a : b) * 1.1
-              : 100.0);
-
-    return Container(
-      padding: const EdgeInsets.all(16),
-      height: 300,
+        return Container(
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
+      height: 320,
       child: LineChart(
         LineChartData(
           gridData: FlGridData(
             show: true,
             drawVerticalLine: false,
             getDrawingHorizontalLine: (value) => FlLine(
-              color: isDark ? Colors.grey[800]! : Colors.grey[300]!,
+              color: AppColors.sectionBorderColor.withAlpha(76),
               strokeWidth: 1,
             ),
           ),
@@ -58,9 +72,16 @@ class SpeedChart extends StatelessWidget {
             rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
             topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
             bottomTitles: AxisTitles(
+              axisNameWidget: Text(
+                'Time (minutes)',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: AppColors.secondaryTextColor,
+                ),
+              ),
               sideTitles: SideTitles(
                 showTitles: true,
-                reservedSize: 30,
+                reservedSize: 40,
                 interval: (speedData.length / 4).ceilToDouble().clamp(
                   1,
                   double.infinity,
@@ -68,10 +89,28 @@ class SpeedChart extends StatelessWidget {
                 getTitlesWidget: (value, meta) {
                   final index = value.toInt();
                   if (index >= 0 && index < speedData.length) {
-                    final minutes = (index / 60).floor();
+                    // Assuming each data point is 1 second
+                    final totalSeconds = index;
+                    final minutes = totalSeconds ~/ 60;
+                    final seconds = totalSeconds % 60;
+                    
+                    // Show time in M:SS format for first few minutes, then just minutes
+                    String timeLabel;
+                    if (minutes < 5 && speedData.length < 600) {
+                      timeLabel = '$minutes:${seconds.toString().padLeft(2, '0')}';
+                    } else {
+                      timeLabel = '${minutes}m';
+                    }
+                    
                     return Padding(
                       padding: const EdgeInsets.only(top: 8.0),
-                      child: Text('${minutes}m'),
+                      child: Text(
+                        timeLabel,
+                        style: TextStyle(
+                          color: AppColors.secondaryTextColor,
+                          fontSize: 10,
+                        ),
+                      ),
                     );
                   }
                   return const Text('');
@@ -79,12 +118,25 @@ class SpeedChart extends StatelessWidget {
               ),
             ),
             leftTitles: AxisTitles(
+              axisNameWidget: Text(
+                'Speed ($speedUnit)',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: AppColors.secondaryTextColor,
+                ),
+              ),
               sideTitles: SideTitles(
                 showTitles: true,
-                reservedSize: 50,
+                reservedSize: 60,
                 interval: ((maxY - minY) / 4).clamp(1.0, double.infinity),
                 getTitlesWidget: (value, meta) {
-                  return Text('${value.toInt()}');
+                  return Text(
+                    '${value.toInt()}',
+                    style: TextStyle(
+                      color: AppColors.secondaryTextColor,
+                      fontSize: 10,
+                    ),
+                  );
                 },
               ),
             ),
@@ -92,7 +144,7 @@ class SpeedChart extends StatelessWidget {
           borderData: FlBorderData(
             show: true,
             border: Border.all(
-              color: isDark ? Colors.grey[800]! : Colors.grey[300]!,
+              color: AppColors.sectionBorderColor,
               width: 1,
             ),
           ),
@@ -102,37 +154,107 @@ class SpeedChart extends StatelessWidget {
           maxY: maxY,
           lineBarsData: [
             LineChartBarData(
-              spots: speedsKmh.asMap().entries.map((entry) {
+              spots: displaySpeeds.asMap().entries.map((entry) {
                 return FlSpot(entry.key.toDouble(), entry.value.toDouble());
               }).toList(),
               isCurved: true,
-              color: Colors.blue,
+              color: AppColors.primaryAccent,
               barWidth: 2,
               isStrokeCapRound: true,
               dotData: FlDotData(show: false),
               belowBarData: BarAreaData(
                 show: true,
-                color: Colors.blue.withValues(alpha: 0.2),
+                color: AppColors.primaryAccent.withAlpha(51),
               ),
             ),
           ],
           lineTouchData: LineTouchData(
+            touchCallback: (FlTouchEvent event, LineTouchResponse? response) {
+              // Handle all touch events that have a response with line bar spots
+              if (response != null && response.lineBarSpots != null && response.lineBarSpots!.isNotEmpty) {
+                final spotIndex = response.lineBarSpots!.first.x.toInt();
+                // Call for any touch event with valid response
+                onPointSelected?.call(spotIndex);
+              }
+            },
             touchTooltipData: LineTouchTooltipData(
+              getTooltipColor: (touchedSpots) => AppColors.sectionBackgroundColor.withAlpha(230),
+              tooltipBorderRadius: BorderRadius.circular(4),
+              tooltipBorder: BorderSide(color: AppColors.primaryTextColor.withAlpha(153), width: 0.5),
+              tooltipPadding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+              tooltipMargin: 8,
+              maxContentWidth: 100,
+              fitInsideHorizontally: true,
+              fitInsideVertically: true,
+              showOnTopOfTheChartBoxArea: false,
               getTooltipItems: (List<LineBarSpot> spots) {
                 return spots.map((spot) {
+                  // Calculate actual time for this data point
+                  String timeString;
+                  if (startTimeZulu != null) {
+                    // Add seconds to start time to get actual timestamp
+                    final actualTime = startTimeZulu!.add(Duration(seconds: spot.x.toInt()));
+                    timeString = '${actualTime.hour.toString().padLeft(2, '0')}:${actualTime.minute.toString().padLeft(2, '0')}:${actualTime.second.toString().padLeft(2, '0')}';
+                  } else {
+                    // Fallback to elapsed time if start time not provided
+                    final totalSeconds = spot.x.toInt();
+                    timeString = '${(totalSeconds ~/ 60).toString().padLeft(2, '0')}:${(totalSeconds % 60).toString().padLeft(2, '0')}';
+                  }
+                  
                   return LineTooltipItem(
-                    '${spot.y.toStringAsFixed(1)} km/h\n${(spot.x / 60).toStringAsFixed(1)} min',
-                    TextStyle(
-                      color: isDark ? Colors.white : Colors.black,
-                      fontWeight: FontWeight.bold,
-                    ),
+                    '',
+                    const TextStyle(),
+                    children: [
+                      TextSpan(
+                        text: '$timeString Z',
+                        style: TextStyle(
+                          color: AppColors.warningColor,
+                          fontSize: 9,
+                          fontWeight: FontWeight.w600,
+                          height: 1.2,
+                        ),
+                      ),
+                      TextSpan(
+                        text: '\n${spot.y.toStringAsFixed(1)} $speedUnit',
+                        style: TextStyle(
+                          color: AppColors.primaryTextColor,
+                          fontSize: 9,
+                          height: 1.2,
+                        ),
+                      ),
+                    ],
                   );
                 }).toList();
               },
             ),
+            handleBuiltInTouches: true,
+            getTouchedSpotIndicator: (LineChartBarData barData, List<int> spotIndexes) {
+              return spotIndexes.map((index) {
+                return TouchedSpotIndicatorData(
+                  FlLine(
+                    color: AppColors.primaryAccent.withAlpha(51),
+                    strokeWidth: 1,
+                    dashArray: [3, 3],
+                  ),
+                  FlDotData(
+                    show: true,
+                    getDotPainter: (spot, percent, barData, index) {
+                      return FlDotCirclePainter(
+                        radius: 3,
+                        color: AppColors.primaryAccent,
+                        strokeWidth: 1.5,
+                        strokeColor: AppColors.primaryTextColor,
+                      );
+                    },
+                  ),
+                );
+              }).toList();
+            },
           ),
         ),
       ),
+        );
+      },
     );
   }
 }

--- a/lib/widgets/vibration_chart.dart
+++ b/lib/widgets/vibration_chart.dart
@@ -1,32 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
+import '../constants/app_colors.dart';
 
 class VibrationChart extends StatelessWidget {
   final List<double> vibrationData; // Vibration intensity values
   final double? currentVibration;
   final double? maxVibration;
+  final DateTime? startTimeZulu;
+  final Function(int)? onPointSelected;
 
   const VibrationChart({
     super.key,
     required this.vibrationData,
     this.currentVibration,
     this.maxVibration,
+    this.startTimeZulu,
+    this.onPointSelected,
   });
 
   @override
   Widget build(BuildContext context) {
     if (vibrationData.isEmpty) {
-      return const Center(
+      return Center(
         child: Text(
-          'No vibration data available\nStart tracking to see vibration data',
+          'No turbulence data available\nStart tracking to see turbulence data',
           textAlign: TextAlign.center,
-          style: TextStyle(color: Colors.grey),
+          style: TextStyle(color: AppColors.tertiaryTextColor),
         ),
       );
     }
 
-    final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
+    // Always use dark theme colors since app has black background
 
     // Calculate min and max for the Y axis
     final minY = 0.0;
@@ -37,15 +41,15 @@ class VibrationChart extends StatelessWidget {
               : 1.0);
 
     return Container(
-      padding: const EdgeInsets.all(16),
-      height: 300,
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
+      height: 320,
       child: LineChart(
         LineChartData(
           gridData: FlGridData(
             show: true,
             drawVerticalLine: false,
             getDrawingHorizontalLine: (value) => FlLine(
-              color: isDark ? Colors.grey[800]! : Colors.grey[300]!,
+              color: AppColors.sectionBorderColor.withAlpha(76),
               strokeWidth: 1,
             ),
           ),
@@ -54,9 +58,16 @@ class VibrationChart extends StatelessWidget {
             rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
             topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
             bottomTitles: AxisTitles(
+              axisNameWidget: Text(
+                'Time (minutes)',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: AppColors.secondaryTextColor,
+                ),
+              ),
               sideTitles: SideTitles(
                 showTitles: true,
-                reservedSize: 30,
+                reservedSize: 40,
                 interval: (vibrationData.length / 4).ceilToDouble().clamp(
                   1,
                   double.infinity,
@@ -64,10 +75,28 @@ class VibrationChart extends StatelessWidget {
                 getTitlesWidget: (value, meta) {
                   final index = value.toInt();
                   if (index >= 0 && index < vibrationData.length) {
-                    final minutes = (index / 60).floor();
+                    // Assuming each data point is 1 second
+                    final totalSeconds = index;
+                    final minutes = totalSeconds ~/ 60;
+                    final seconds = totalSeconds % 60;
+                    
+                    // Show time in M:SS format for first few minutes, then just minutes
+                    String timeLabel;
+                    if (minutes < 5 && vibrationData.length < 600) {
+                      timeLabel = '$minutes:${seconds.toString().padLeft(2, '0')}';
+                    } else {
+                      timeLabel = '${minutes}m';
+                    }
+                    
                     return Padding(
                       padding: const EdgeInsets.only(top: 8.0),
-                      child: Text('${minutes}m'),
+                      child: Text(
+                        timeLabel,
+                        style: TextStyle(
+                          color: AppColors.secondaryTextColor,
+                          fontSize: 10,
+                        ),
+                      ),
                     );
                   }
                   return const Text('');
@@ -75,12 +104,25 @@ class VibrationChart extends StatelessWidget {
               ),
             ),
             leftTitles: AxisTitles(
+              axisNameWidget: Text(
+                'Turbulence (g)',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: AppColors.secondaryTextColor,
+                ),
+              ),
               sideTitles: SideTitles(
                 showTitles: true,
-                reservedSize: 50,
+                reservedSize: 60,
                 interval: (maxY / 4).clamp(0.1, double.infinity),
                 getTitlesWidget: (value, meta) {
-                  return Text(value.toStringAsFixed(1));
+                  return Text(
+                    value.toStringAsFixed(1),
+                    style: TextStyle(
+                      color: AppColors.secondaryTextColor,
+                      fontSize: 10,
+                    ),
+                  );
                 },
               ),
             ),
@@ -88,7 +130,7 @@ class VibrationChart extends StatelessWidget {
           borderData: FlBorderData(
             show: true,
             border: Border.all(
-              color: isDark ? Colors.grey[800]! : Colors.grey[300]!,
+              color: AppColors.sectionBorderColor,
               width: 1,
             ),
           ),
@@ -104,30 +146,98 @@ class VibrationChart extends StatelessWidget {
                 return FlSpot(entry.key.toDouble(), entry.value);
               }).toList(),
               isCurved: true,
-              color: Colors.orange,
+              color: AppColors.warningColor,
               barWidth: 2,
               isStrokeCapRound: true,
               dotData: FlDotData(show: false),
               belowBarData: BarAreaData(
                 show: true,
-                color: Colors.orange.withValues(alpha: 0.2),
+                color: AppColors.warningColor.withAlpha(51),
               ),
             ),
           ],
           lineTouchData: LineTouchData(
+            touchCallback: (FlTouchEvent event, LineTouchResponse? response) {
+              // Handle all touch events that have a response with line bar spots
+              if (response != null && response.lineBarSpots != null && response.lineBarSpots!.isNotEmpty) {
+                final spotIndex = response.lineBarSpots!.first.x.toInt();
+                // Call for any touch event with valid response
+                onPointSelected?.call(spotIndex);
+              }
+            },
             touchTooltipData: LineTouchTooltipData(
+              getTooltipColor: (touchedSpots) => AppColors.sectionBackgroundColor.withAlpha(230),
+              tooltipBorderRadius: BorderRadius.circular(4),
+              tooltipBorder: BorderSide(color: AppColors.primaryTextColor.withAlpha(153), width: 0.5),
+              tooltipPadding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+              tooltipMargin: 8,
+              maxContentWidth: 100,
+              fitInsideHorizontally: true,
+              fitInsideVertically: true,
+              showOnTopOfTheChartBoxArea: false,
               getTooltipItems: (List<LineBarSpot> spots) {
                 return spots.map((spot) {
+                  // Calculate actual time for this data point
+                  String timeString;
+                  if (startTimeZulu != null) {
+                    // Add seconds to start time to get actual timestamp
+                    final actualTime = startTimeZulu!.add(Duration(seconds: spot.x.toInt()));
+                    timeString = '${actualTime.hour.toString().padLeft(2, '0')}:${actualTime.minute.toString().padLeft(2, '0')}:${actualTime.second.toString().padLeft(2, '0')}';
+                  } else {
+                    // Fallback to elapsed time if start time not provided
+                    final totalSeconds = spot.x.toInt();
+                    timeString = '${(totalSeconds ~/ 60).toString().padLeft(2, '0')}:${(totalSeconds % 60).toString().padLeft(2, '0')}';
+                  }
+                  
                   return LineTooltipItem(
-                    '${spot.y.toStringAsFixed(2)} g\n${(spot.x / 60).toStringAsFixed(1)} min',
-                    TextStyle(
-                      color: isDark ? Colors.white : Colors.black,
-                      fontWeight: FontWeight.bold,
-                    ),
+                    '',
+                    const TextStyle(),
+                    children: [
+                      TextSpan(
+                        text: '$timeString Z',
+                        style: TextStyle(
+                          color: AppColors.warningColor,
+                          fontSize: 9,
+                          fontWeight: FontWeight.w600,
+                          height: 1.2,
+                        ),
+                      ),
+                      TextSpan(
+                        text: '\n${spot.y.toStringAsFixed(2)} g',
+                        style: TextStyle(
+                          color: AppColors.primaryTextColor,
+                          fontSize: 9,
+                          height: 1.2,
+                        ),
+                      ),
+                    ],
                   );
                 }).toList();
               },
             ),
+            handleBuiltInTouches: true,
+            getTouchedSpotIndicator: (LineChartBarData barData, List<int> spotIndexes) {
+              return spotIndexes.map((index) {
+                return TouchedSpotIndicatorData(
+                  FlLine(
+                    color: AppColors.warningColor.withAlpha(51),
+                    strokeWidth: 1,
+                    dashArray: [3, 3],
+                  ),
+                  FlDotData(
+                    show: true,
+                    getDotPainter: (spot, percent, barData, index) {
+                      return FlDotCirclePainter(
+                        radius: 3,
+                        color: AppColors.warningColor,
+                        strokeWidth: 1.5,
+                        strokeColor: AppColors.primaryTextColor,
+                      );
+                    },
+                  ),
+                );
+              }).toList();
+            },
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- ✨ Added interactive map markers that show selected points from charts
- 🐛 Fixed multiple UI overflow issues
- 🎨 Improved user experience with non-modal notifications

## Features

### Interactive Chart-to-Map Markers
- When users tap or drag on Speed, Turbulence, or Altitude charts, a marker appears on the map
- The marker shows the exact GPS location for the selected time point
- Orange marker with white border for high visibility
- Works seamlessly across all three chart types

### UI/UX Improvements
- Converted blocking modal dialog to non-modal SnackBar for flight plan checking
- Auto-dismisses after 5 seconds for better user flow
- Fixed RenderFlex overflow errors in logbook entries
- Fixed SnackBar text overflow on map screen

### Chart Enhancements
- Real-time Zulu time display in tooltips
- Fixed time axis showing proper minutes
- Added white borders to tooltips for better visibility
- Unit conversion support (metric/imperial) based on user settings

## Testing
1. Open a flight detail screen with chart data
2. Navigate to Speed, Turbulence, or Altitude tabs
3. Tap or drag on the chart - verify orange marker appears on map
4. Check logbook entries - verify no overflow errors
5. Trigger flight plan checking - verify non-modal notification appears

## Screenshots
The orange marker with white border appears at the GPS location corresponding to the selected chart point.

🤖 Generated with [Claude Code](https://claude.ai/code)